### PR TITLE
fix get_latest_counter

### DIFF
--- a/qdev_wrappers/transmon/file_helpers.py
+++ b/qdev_wrappers/transmon/file_helpers.py
@@ -114,7 +114,7 @@ def get_latest_counter(path=None):
         raise OSError('Error looking for files in {}:'
                       ''.format(path, e))
     if not file_ints:
-        raise OSError('No numbered files in ' + path)
+        raise OSError('No files found in ' + path + ' that start with a number.)
     return max(file_ints)
 
 

--- a/qdev_wrappers/transmon/file_helpers.py
+++ b/qdev_wrappers/transmon/file_helpers.py
@@ -108,11 +108,11 @@ def get_latest_counter(path=None):
     if path is None:
         path = get_data_location()
     try:
-        file_names = [re.sub("[^0-9]", "", f) for f in os.listdir(path)]
+        file_strs = [re.match("^([0-9]+)", f) for f in os.listdir(path)]
+        file_ints = [int(i.groups()[0]) for i in file_strs if i]
     except OSError as e:
-        raise OSError('Error looking for numbered files in {}:'
+        raise OSError('Error looking for files in {}:'
                       ''.format(path, e))
-    file_ints = [int(f) for f in file_names if f]
     if not file_ints:
         raise OSError('No numbered files in ' + path)
     return max(file_ints)

--- a/qdev_wrappers/transmon/file_helpers.py
+++ b/qdev_wrappers/transmon/file_helpers.py
@@ -114,7 +114,7 @@ def get_latest_counter(path=None):
         raise OSError('Error looking for files in {}:'
                       ''.format(path, e))
     if not file_ints:
-        raise OSError('No files found in ' + path + ' that start with a number.)
+        raise OSError('No files found in ' + path + ' that start with a number.')
     return max(file_ints)
 
 


### PR DESCRIPTION
this fixes a slightly hacky function in the transmon wrappers which gets the highest number corresponding to the name of a file in a folder. It is used for creating numbered file names and previously led to problems because it got all the numbers in a name and returned the composite int (eg "12_t2" -> "122"), now it returns the first uninterrupted number (eg "12_t2" -> "12")