### PR TITLE
add (back) in data_num concept

### DIFF
--- a/qdev_wrappers/sweep_functions.py
+++ b/qdev_wrappers/sweep_functions.py
@@ -85,7 +85,8 @@ def _do_measurement_single(measurement: Measure, meas_params: tuple,
             plot.save()
             if 'pdf_subfolder' in CURRENT_EXPERIMENT:
                 plt.ioff()
-                pdfplot, num_subplots = _plot_setup(data, meas_params, useQT=False)
+                pdfplot, num_subplots = _plot_setup(
+                    data, meas_params, useQT=False)
                 # pad a bit more to prevent overlap between
                 # suptitle and title
                 pdfplot.rescale_axis()
@@ -159,7 +160,8 @@ def _do_measurement(loop: Loop, set_params: tuple, meas_params: tuple,
 
         if do_plots:
             try:
-                plot, _ = _plot_setup(data, meas_params, startranges=startranges)
+                plot, _ = _plot_setup(
+                    data, meas_params, startranges=startranges)
             except (ClosedError, ConnectionError):
                 log.warning('Remote process crashed png will not be saved')
         else:
@@ -182,7 +184,8 @@ def _do_measurement(loop: Loop, set_params: tuple, meas_params: tuple,
 
             if any(k in CURRENT_EXPERIMENT for k in ('pdf_subfolder', 'png_subfolder')):
                 plt.ioff()
-                pdfplot, num_subplots = _plot_setup(data, meas_params, useQT=False)
+                pdfplot, num_subplots = _plot_setup(
+                    data, meas_params, useQT=False)
                 # pad a bit more to prevent overlap between
                 # suptitle and title
                 pdfplot.rescale_axis()
@@ -197,10 +200,11 @@ def _do_measurement(loop: Loop, set_params: tuple, meas_params: tuple,
                 if 'png_subfolder' in CURRENT_EXPERIMENT:
                     # Hack to save PNG also
                     title_list_png = plot.get_default_title().split(sep)
-                    title_list_png.insert(-1, CURRENT_EXPERIMENT['png_subfolder'])
+                    title_list_png.insert(-1,
+                                          CURRENT_EXPERIMENT['png_subfolder'])
                     title_png = sep.join(title_list_png)
 
-                    plt.savefig("{}.png".format(title_png),dpi=500)
+                    plt.savefig("{}.png".format(title_png), dpi=500)
 
                 if (pdfdisplay['combined'] or
                         (num_subplots == 1 and pdfdisplay['individual'])):
@@ -260,7 +264,7 @@ def do1d(inst_set, start, stop, num_points, delay, *inst_meas, do_plots=True,
 
     plot, data = _do_measurement(loop, set_params, meas_params,
                                  do_plots=do_plots, use_threads=use_threads)
-
+    data.data_num = qc.data.data_set.DataSet.location_provider.counter
     return plot, data
 
 
@@ -303,7 +307,7 @@ def do1dDiagonal(inst_set, inst2_set, start, stop, num_points,
 
     plot, data = _do_measurement(loop, set_params, meas_params,
                                  do_plots=do_plots, use_threads=use_threads)
-
+    data.data_num = qc.data.data_set.DataSet.location_provider.counter
     return plot, data
 
 
@@ -353,7 +357,7 @@ def do2d(inst_set, start, stop, num_points, delay,
 
     plot, data = _do_measurement(outerloop, set_params, meas_params,
                                  do_plots=do_plots, use_threads=use_threads)
-
+    data.data_num = qc.data.data_set.DataSet.location_provider.counter
     return plot, data
 
 
@@ -372,4 +376,5 @@ def do0d(*inst_meas, do_plots=True, use_threads=True):
     meas_params = _select_plottables(inst_meas)
     plot, data = _do_measurement_single(
         measurement, meas_params, do_plots=do_plots, use_threads=use_threads)
+    data.data_num = qc.data.data_set.DataSet.location_provider.counter
     return plot, data

--- a/qdev_wrappers/transmon/analysis_helpers.py
+++ b/qdev_wrappers/transmon/analysis_helpers.py
@@ -65,8 +65,8 @@ def find_peaks(dataset, fs, x_key="set", y_key="mag", cutoff=5e-6, order=2,
     try:
         num = dataset.data_num
     except AttributeError:
-        num = dataset.location_provider.counter
-        print('warning: check title, could be wrong datanum')
+        num = None
+        print('dataset has no data_num set, title may be non specific')
 
     # plot: unsmoothed data, smoothed data and add peak estimate values
     fig, subplot = plot_cf_data([unsmoothed_data, smoothed_data],
@@ -162,7 +162,7 @@ def get_resonator_push(dataset, x_key="freq", y_key="pow", z_key="mag"):
         fig.text(0, 0, 'bare res: {}, pushed res: {}, push: {}'.format(
             high_res, low_res, dif))
     except AttributeError as e:
-        fig.data_num = dataset.location_provider.counter
+        fig.data_num = None
         print('dataset has no data_num set: {}'.format(e))
 
     return low_res, high_res, fig
@@ -298,7 +298,12 @@ def get_t2(data, x_name='delay', y_name='magnitude',
         else:
             ax = subplot
             fig = ax.figure
-        num = data.data_num
+        try:
+            num = data.data_num
+        except AttributeError:
+            num = None
+            print('dataset has no data_num set, title may be non specific')
+
         try:
             qubit = get_calibration_dict()['current_qubit']
             title = '{}_{}_T2'.format(get_title(num), qubit)
@@ -307,12 +312,12 @@ def get_t2(data, x_name='delay', y_name='magnitude',
             title = '{}_T2'.format(get_title(num))
             name = '{}_T2'.format(num)
 
-        if not hasattr(fig, "data_num"):
+        if (not hasattr(fig, "data_num") or fig.data_num is None):
             fig.data_num = num
         ax.plot(x_data,
                 exp_decay_sin(x_data, *popt),
                 label='fit: T2 {:.3g}{}'.format(popt[1],
-                                            x_units))
+                                                x_units))
         ax.plot(x_data, y_data, label='data')
         ax.set_xlabel('{} ({})'.format(x_name, x_units))
         ax.set_ylabel('{} ({})'.format(y_name, y_units))
@@ -357,7 +362,11 @@ def get_t1(data, x_name='delay', y_name='magnitude',
         else:
             ax = subplot
             fig = ax.figure
-        num = data.data_num
+        try:
+            num = data.data_num
+        except AttributeError:
+            num = None
+            print('dataset has no data_num set, title may be non specific')
         try:
             qubit = get_calibration_dict()['current_qubit']
             title = '{}_{}_T1'.format(get_title(num), qubit)
@@ -366,12 +375,12 @@ def get_t1(data, x_name='delay', y_name='magnitude',
             title = '{}_T1'.format(get_title(num))
             name = '{}_T1'.format(num)
 
-        if not hasattr(fig, "data_num"):
+        if (not hasattr(fig, "data_num") or fig.data_num is None):
             fig.data_num = num
         ax.plot(x_data,
                 exp_decay(x_data, *popt),
                 label='fit: T1 {:.3g}{}'.format(popt[1],
-                                            x_units))
+                                                x_units))
         ax.plot(x_data, y_data, label='data')
         ax.set_xlabel('{} ({})'.format(x_name, x_units))
         ax.set_ylabel('{} ({})'.format(y_name, y_units))

--- a/qdev_wrappers/transmon/loading_data.py
+++ b/qdev_wrappers/transmon/loading_data.py
@@ -25,6 +25,7 @@ def load(counter, plot=True, metadata=True, matplot=False):
     """
     useQT = not matplot
     dataset, plots = show_num(counter, do_plot=plot, useQT=useQT)
+    dataset.data_num = counter
     if metadata:
         _ = get_metadata(dataset, printout=True)
         _ = _get_data_duration(dataset)

--- a/qdev_wrappers/transmon/sweep_helpers.py
+++ b/qdev_wrappers/transmon/sweep_helpers.py
@@ -21,7 +21,7 @@ def measure(meas_param, do_plots=True):
     meas_params = _select_plottables(meas_param)
     plot, data = _do_measurement_single(
         measurement, meas_params, do_plots=do_plots)
-
+    data.data_num = qc.data.data_set.DataSet.location_provider.counter
     return data, plot
 
 
@@ -52,7 +52,7 @@ def sweep1d(meas_param, sweep_param, start, stop, step, delay=0.01,
 
     plot, data = _do_measurement(loop, set_params, meas_params,
                                  do_plots=do_plots)
-
+    data.data_num = qc.data.data_set.DataSet.location_provider.counter
     return data, plot
 
 
@@ -93,5 +93,5 @@ def sweep2d(meas_param, sweep_param1, start1, stop1, step1,
 
     plot, data = _do_measurement(outerloop, set_params, meas_params,
                                  do_plots=do_plots)
-
+    data.data_num = qc.data.data_set.DataSet.location_provider.counter
     return data, plot


### PR DESCRIPTION
This is a short term solution to the fact that datasets do not have an easily accessible id so you have to instead use the qc.data.data_set.DataSet.location_provider.counter to find out what the most recent data_set taken was. This number is then set as an attribute of the dataset so that if I want to use the dataset to create an analysis plot or similar it is easy to get the counter at the time this dataset was taken and use that as a title or when saving.