### PR TITLE
Fix alazar

### DIFF
--- a/qdev_wrappers/alazar_controllers/ATS9360Controller.py
+++ b/qdev_wrappers/alazar_controllers/ATS9360Controller.py
@@ -8,7 +8,7 @@ from .acquisition_parametersold import AcqVariablesParam, \
                                        NonSettableDerivedParameter, \
                                        DemodFreqParameter
 
-
+log = logging.getLogger(__name__)
 class ATS9360Controller(AcquisitionController):
     """
     This is the Acquisition Controller class which works with the ATS9360,
@@ -134,8 +134,10 @@ class ATS9360Controller(AcquisitionController):
         """
         total_time = (int_time or 0) + (int_delay or 0)
         samples_needed = total_time * sample_rate
+        log.info("needing {} samples at total time {} with sample rate {}".format(samples_needed, total_time, sample_rate))
         samples_per_record = helpers.roundup(
             samples_needed, self.samples_divisor)
+        log.info("rounding up samples pr record to {}".format(samples_per_record))
         self.samples_per_record._save_val(samples_per_record)
         self.acquisition.set_setpoints_and_labels()
 

--- a/qdev_wrappers/alazar_controllers/acq_helpers.py
+++ b/qdev_wrappers/alazar_controllers/acq_helpers.py
@@ -36,10 +36,10 @@ def roundup(num, to_nearest):
         rounded up value
 
     """
-    # remainder = num % to_nearest
-    # divisor = num // to_nearest
-    # return int(num if remainder == 0 else (divisor + 1)*to_nearest)
+    remainder = num % to_nearest
+    divisor = num // to_nearest
+    return int(num if remainder == 0 else (divisor + 1)*to_nearest)
     # there seems to be alignment related issues with non power of two
     # buffers so restrict to power of two for now
-    smallest_power = 2 ** math.ceil(math.log2(num))
-    return max(smallest_power, 256)
+    # smallest_power = 2 ** math.ceil(math.log2(num))
+    # return max(smallest_power, 256)

--- a/qdev_wrappers/alazar_controllers/acquisition_parametersold.py
+++ b/qdev_wrappers/alazar_controllers/acquisition_parametersold.py
@@ -2,6 +2,8 @@ from qcodes import Parameter, MultiParameter, ArrayParameter
 import numpy as np
 import logging
 
+log = logging.getLogger(__name__)
+
 class AcqVariablesParam(Parameter):
     """
     Parameter of an AcquisitionController which has a _check_and_update_instr
@@ -279,13 +281,12 @@ class ExpandingAlazarArrayMultiParameter(MultiParameter):
 
     def set_setpoints_and_labels(self):
         if not self._integrate_samples:
-            int_time = self._instrument.int_time.get() or 0
-            int_delay = self._instrument.int_delay.get() or 0
-            total_time = int_time + int_delay
             samples = self._instrument.samples_per_record.get()
-            if total_time and samples:
+            sample_rate = self._instrument._get_alazar().get_sample_rate()
+            log.info("setting setpoints from {} sample_rate and samples {}".format(sample_rate, samples))
+            if sample_rate and samples:
                 start = 0
-                stop = total_time
+                stop = samples/sample_rate
             else:
                 start = 0
                 stop = 1
@@ -478,14 +479,14 @@ class DemodFreqParameter(ArrayParameter):
         oversampling = sample_rate / (2 * value)
         if min_oscillations_measured < 10:
             isValid = False
-            logging.warning('{} oscillation measured for largest '
+            log.warning('{} oscillation measured for largest '
                             'demod freq, recommend at least 10: '
                             'decrease sampling rate, take '
                             'more samples or increase demodulation '
                             'freq'.format(min_oscillations_measured))
         elif oversampling < 1:
             isValid = False
-            logging.warning('oversampling rate is {}, recommend > 1: '
+            log.warning('oversampling rate is {}, recommend > 1: '
                             'increase sampling rate or decrease '
                             'demodulation frequency'.format(oversampling))
 

--- a/qdev_wrappers/customised_instruments/AlazarTech_ATS9360_ext.py
+++ b/qdev_wrappers/customised_instruments/AlazarTech_ATS9360_ext.py
@@ -36,7 +36,8 @@ class AlazarTech_ATS9360_ext(AlazarTech_ATS9360):
                              '"off", received {}'.format(seq_mode))
         super().__init__(name=name)
         self.config(clock_source='EXTERNAL_CLOCK_10MHz_REF',
-                    sample_rate=500000000,
+                    #sample_rate=500_000_000,
+                    external_sample_rate=500_000_000,
                     clock_edge='CLOCK_EDGE_RISING',
                     decimation=1,
                     coupling=['DC', 'DC'],


### PR DESCRIPTION


* Calculate set points from sample rate rather than int time to get the correct timings
* allow non power of two number of samples (this was originally disabled because it looked like it might be the source of corrupt data. I no longer think that it is)
* In init script set the right sampling rate that is actually used for external. (this probably does not matter as this is the same as the default)
* Better logging