### PR TITLE
Fixing the QDac aliases

### DIFF
--- a/qdev_wrappers/customised_instruments/QDAC_ext.py
+++ b/qdev_wrappers/customised_instruments/QDAC_ext.py
@@ -15,7 +15,13 @@ class QDAC_ext(QDac):
         # same as in decadac but without fine mode
 
         for attribute, settings in config.get('QDAC').items():
-            channel = getattr(self, attribute)
+            try:
+                channel = getattr(self, attribute)
+            except AttributeError as e:
+                raise AttributeError(e.message +
+                                     'config file implementation has changed:\n'+
+                                     '\'1 = ... -> chan02 = ...\' make sure to'+
+                                     ' increment the channel number!')
 
             config_settings = settings.split(',')
 

--- a/qdev_wrappers/customised_instruments/QDAC_ext.py
+++ b/qdev_wrappers/customised_instruments/QDAC_ext.py
@@ -13,8 +13,28 @@ class QDAC_ext(QDac):
         super().__init__(name, address, **kwargs)
 
         # same as in decadac but without fine mode
-        for channelNum, settings in config.get('QDAC').items():
-            channel = self.channels[int(channelNum)]
+
+        # load from config file whether enumeration should start
+        # at zero or one.
+        dac_config = config.get('QDac')
+        enum_mode = dac_config.get('enumeration', 'zero_based')
+        offset = 0
+        if enum_mode == 'zero_based':
+            pass
+        elif enum_mode == 'one_based':
+            offset = 1
+        else:
+            raise RuntimeError(
+                ('The enumeration attribute has to be either ' +
+                ' \'zero_based\' or \'one_based\' not {}').
+                format(enum_mode))
+
+        for attribute, settings in config.get('QDAC').items():
+            try:
+                channel = self.channels[int(attribute)] + offset
+            except TypeError:
+                continue
+
             config_settings = settings.split(',')
 
             name = config_settings[0]

--- a/qdev_wrappers/customised_instruments/QDAC_ext.py
+++ b/qdev_wrappers/customised_instruments/QDAC_ext.py
@@ -14,26 +14,8 @@ class QDAC_ext(QDac):
 
         # same as in decadac but without fine mode
 
-        # load from config file whether enumeration should start
-        # at zero or one.
-        dac_config = config.get('QDac')
-        enum_mode = dac_config.get('enumeration', 'zero_based')
-        offset = 0
-        if enum_mode == 'zero_based':
-            pass
-        elif enum_mode == 'one_based':
-            offset = 1
-        else:
-            raise RuntimeError(
-                ('The enumeration attribute has to be either ' +
-                ' \'zero_based\' or \'one_based\' not {}').
-                format(enum_mode))
-
         for attribute, settings in config.get('QDAC').items():
-            try:
-                channel = self.channels[int(attribute)] + offset
-            except TypeError:
-                continue
+            channel = getattr(self, attribute)
 
             config_settings = settings.split(',')
 
@@ -41,8 +23,8 @@ class QDAC_ext(QDac):
             label = config_settings[1]
             unit = config_settings[2]
             divisor = float(config_settings[3])
-            step = float(config_settings[4])
-            delay = float(config_settings[5])
+            # step = float(config_settings[4])
+            # delay = float(config_settings[5])
             rangemin = float(config_settings[6])
             rangemax = float(config_settings[7])
 

--- a/qdev_wrappers/templates/instr.config
+++ b/qdev_wrappers/templates/instr.config
@@ -22,13 +22,13 @@
 
 [QDAC]
 # this is an example on how to use this config file
-chan01 = Q1lplg,Q1 left plunger,V,1,0.1,0.1,-10,10
-chan02 = Q1cut,Q1 cutter,V,1,0.1,0.1,-10,10
-chan05 = Q1rplg,Q1 right plunger,V,1,0.1,0.1,-10,10
-chan09 = Q2cut,Q2 cutter,V,1,0.1,0.1,-10,10
-chan10 = Q2lplg,Q2 left plunger,V,1,0.1,0.1,-10,10
-chan14 = Q2rplg,Q2 right plunger,V,1,0.1,0.1,-10,10
-chan18 = By,By,T,28.692,0.1,0.1,-10,10,coarse
+ch01 = Q1lplg,Q1 left plunger,V,1,0.1,0.1,-10,10
+ch02 = Q1cut,Q1 cutter,V,1,0.1,0.1,-10,10
+ch05 = Q1rplg,Q1 right plunger,V,1,0.1,0.1,-10,10
+ch09 = Q2cut,Q2 cutter,V,1,0.1,0.1,-10,10
+ch10 = Q2lplg,Q2 left plunger,V,1,0.1,0.1,-10,10
+ch14 = Q2rplg,Q2 right plunger,V,1,0.1,0.1,-10,10
+ch18 = By,By,T,28.692,0.1,0.1,-10,10,coarse
 
 [Gain Settings]
 iv gain = 1e8

--- a/qdev_wrappers/templates/instr.config
+++ b/qdev_wrappers/templates/instr.config
@@ -22,13 +22,13 @@
 
 [QDAC]
 # this is an example on how to use this config file
-0 = Q1lplg,Q1 left plunger,V,1,0.1,0.1,-10,10
-1 = Q1cut,Q1 cutter,V,1,0.1,0.1,-10,10
-4 = Q1rplg,Q1 right plunger,V,1,0.1,0.1,-10,10
-8 = Q2cut,Q2 cutter,V,1,0.1,0.1,-10,10
-9 = Q2lplg,Q2 left plunger,V,1,0.1,0.1,-10,10
-13 = Q2rplg,Q2 right plunger,V,1,0.1,0.1,-10,10
-17 = By,By,T,28.692,0.1,0.1,-10,10,coarse
+chan01 = Q1lplg,Q1 left plunger,V,1,0.1,0.1,-10,10
+chan02 = Q1cut,Q1 cutter,V,1,0.1,0.1,-10,10
+chan05 = Q1rplg,Q1 right plunger,V,1,0.1,0.1,-10,10
+chan09 = Q2cut,Q2 cutter,V,1,0.1,0.1,-10,10
+chan10 = Q2lplg,Q2 left plunger,V,1,0.1,0.1,-10,10
+chan14 = Q2rplg,Q2 right plunger,V,1,0.1,0.1,-10,10
+chan18 = By,By,T,28.692,0.1,0.1,-10,10,coarse
 
 [Gain Settings]
 iv gain = 1e8


### PR DESCRIPTION
This fixes #50 the problem of the qdac channels being numbered starting at 1 while channels are numbered from zero.
In the `instr.config`
```
0 = Q1lplg,Q1 left plunger,V,1,0.1,0.1,-10,10
```
leads to the assignment of channel 1.
With this PR the config has be written as:
```
ch01 = Q1lplg,Q1 left plunger,V,1,0.1,0.1,-10,10
```
(note 0 changed to 1)
Here `ch` is added to throw an error if the config file is unchanged, instead of simply shifting all channels and possibly breaking devices.