### PR TITLE
Feat/do2d set second parameter first

### DIFF
--- a/qdev_wrappers/sweep_functions.py
+++ b/qdev_wrappers/sweep_functions.py
@@ -316,8 +316,8 @@ def do2d(inst_set, start, stop, num_points, delay,
             Data is still saved and can be displayed with show_num.
         use_threads: If True and if multiple things are being measured,
             multiple threads will be used to parallelise the waiting.
-        set_before_sweep: if True the first parameter is set to its first value
-            before the second parameter is swept to its next value.
+        set_before_sweep: if True the outer parameter is set to its first value
+            before the inner parameter is swept to its next value.
 
     Returns:
         plot, data : returns the plot and the dataset

--- a/qdev_wrappers/sweep_functions.py
+++ b/qdev_wrappers/sweep_functions.py
@@ -344,9 +344,9 @@ def do2d(inst_set, start, stop, num_points, delay,
         ateach = [innerloop]
 
     if outerloop_pre_tasks is not None:
-        ateach = outerloop_pre_tasks + ateach
+        ateach = list(outerloop_pre_tasks) + ateach
     if outerloop_post_tasks is not None:
-        ateach = ateach + outerloop_post_tasks
+        ateach = ateach + list(outerloop_post_tasks)
 
     outerloop = qc.Loop(inst_set.sweep(start,
                                        stop,

--- a/qdev_wrappers/sweep_functions.py
+++ b/qdev_wrappers/sweep_functions.py
@@ -1,6 +1,6 @@
 import matplotlib.pyplot as plt
 from os.path import sep
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Sequence
 from pyqtgraph.multiprocess.remoteproxy import ClosedError
 
 import qcodes as qc
@@ -297,7 +297,9 @@ def do1dDiagonal(inst_set, inst2_set, start, stop, num_points,
 def do2d(inst_set, start, stop, num_points, delay,
          inst_set2, start2, stop2, num_points2, delay2,
          *inst_meas, do_plots=True, use_threads=False,
-         set_before_sweep: Optional[bool]=False):
+         set_before_sweep: Optional[bool]=False,
+         outerloop_pre_tasks: Optional[Sequence]=None,
+         outerloop_post_tasks: Optional[Sequence]=None):
     """
 
     Args:
@@ -318,6 +320,10 @@ def do2d(inst_set, start, stop, num_points, delay,
             multiple threads will be used to parallelise the waiting.
         set_before_sweep: if True the outer parameter is set to its first value
             before the inner parameter is swept to its next value.
+        outerloop_pre_tasks: Tasks to execute before each iteration of the
+            outer loop
+        outerloop_post_tasks: Tasks to execute after each iteration of the
+            outer loop
 
     Returns:
         plot, data : returns the plot and the dataset
@@ -336,6 +342,11 @@ def do2d(inst_set, start, stop, num_points, delay,
         ateach = [innerloop, Task(inst_set2, start2)]
     else:
         ateach = [innerloop]
+
+    if outerloop_pre_tasks is not None:
+        ateach = outerloop_pre_tasks + ateach
+    if outerloop_post_tasks is not None:
+        ateach = ateach + outerloop_post_tasks
 
     outerloop = qc.Loop(inst_set.sweep(start,
                                        stop,

--- a/qdev_wrappers/sweep_functions.py
+++ b/qdev_wrappers/sweep_functions.py
@@ -6,6 +6,7 @@ from pyqtgraph.multiprocess.remoteproxy import ClosedError
 import qcodes as qc
 from qcodes.instrument.visa import VisaInstrument
 from qcodes.plots.pyqtgraph import QtPlot
+from qcodes.actions import Task
 from qcodes.data.data_set import DataSet
 from qcodes.loops import Loop
 from qcodes.measure import Measure
@@ -295,7 +296,8 @@ def do1dDiagonal(inst_set, inst2_set, start, stop, num_points,
 
 def do2d(inst_set, start, stop, num_points, delay,
          inst_set2, start2, stop2, num_points2, delay2,
-         *inst_meas, do_plots=True, use_threads=False):
+         *inst_meas, do_plots=True, use_threads=False,
+         set_before_sweep: Optional[bool]=False):
     """
 
     Args:
@@ -314,6 +316,8 @@ def do2d(inst_set, start, stop, num_points, delay,
             Data is still saved and can be displayed with show_num.
         use_threads: If True and if multiple things are being measured,
             multiple threads will be used to parallelise the waiting.
+        set_before_sweep: if True the first parameter is set to its first value
+            before the second parameter is swept to its next value.
 
     Returns:
         plot, data : returns the plot and the dataset
@@ -328,10 +332,15 @@ def do2d(inst_set, start, stop, num_points, delay,
                                         stop2,
                                         num=num_points2),
                         delay2).each(*inst_meas)
+    if set_before_sweep:
+        ateach = [innerloop, Task(inst_set2, start2)]
+    else:
+        ateach = [innerloop]
+
     outerloop = qc.Loop(inst_set.sweep(start,
                                        stop,
                                        num=num_points),
-                        delay).each(innerloop)
+                        delay).each(*ateach)
 
     set_params = ((inst_set, start, stop),
                   (inst_set2, start2, stop2))


### PR DESCRIPTION
Build on top of #58:

Adding a feature to use do2d to set the first swept parameter to its start value before setting the second parameter to its new value. See image for clarification:
[drawing.pdf](https://github.com/qdev-dk/qdev-wrappers/files/1703987/drawing.pdf)
In this drawing the red line corresponds to parameter 1 and the blue line to parameter 2. Parameter 1 can only be set by slowly sweeping it. In the upper graph the p2 only gets reset to the start value when p1 has finished the ramp. In the lower it is set before the ramp.
In this PR I implemented the option to choose between these two options. (without it the default corresponds to the upper version)

To test the behaviour use:
```
import qcodes as qc
from qdev_wrappers.sweep_functions import do2d
from qdev_wrappers.file_setup import CURRENT_EXPERIMENT

CURRENT_EXPERIMENT['sample_name'] = 'bs'
CURRENT_EXPERIMENT['plot_x_position'] = 0
CURRENT_EXPERIMENT['logfile'] = 'bs.log'

val = 0

def setval(v):
    global val
    val = v
    print('setting 1 to {}'.format(val))

val2 = 0

def setval2(v):
    global val2
    val2 = v
    print('setting 2 to {}'.format(val2))

def getvals():
    global val
    global val2
    print('measuring: {}'.format(val+val2))
    # print('{},\t{}'.format(val, val2))
    return val+val2

pwrite=qc.Parameter('out', set_cmd=setval)
pread=qc.Parameter('in', get_cmd=getvals)
pwrite2=qc.Parameter('out2', set_cmd=setval2)

do2d(pwrite, 0.,1.,3,0,pwrite2,0.,1.,3,0, pread, set_before_sweep=True)
```

This produces:
```
setting 1 to 0.0
setting 2 to 0.0
measuring: 0.0
setting 2 to 0.5
measuring: 0.5
setting 2 to 1.0
measuring: 1.0
setting 2 to 0.0
setting 1 to 0.5
setting 2 to 0.0
measuring: 0.5
setting 2 to 0.5
measuring: 1.0
setting 2 to 1.0
measuring: 1.5
setting 2 to 0.0
setting 1 to 1.0
setting 2 to 0.0
measuring: 1.0
setting 2 to 0.5
measuring: 1.5
setting 2 to 1.0
measuring: 2.0
setting 2 to 0.0
```
with `set_before_sweep=False` the standard behaviour is reestablished:
```
setting 1 to 0.0
setting 2 to 0.0
measuring: 0.0
setting 2 to 0.5
measuring: 0.5
setting 2 to 1.0
measuring: 1.0
setting 1 to 0.5
setting 2 to 0.0
measuring: 0.5
setting 2 to 0.5
measuring: 1.0
setting 2 to 1.0
measuring: 1.5
setting 1 to 1.0
setting 2 to 0.0
measuring: 1.0
setting 2 to 0.5
measuring: 1.5
setting 2 to 1.0
measuring: 2.0
```
