### PR TITLE
Feat/logging module

### DIFF
--- a/qdev_wrappers/__init__.py
+++ b/qdev_wrappers/__init__.py
@@ -1,3 +1,4 @@
+from qdev_wrappers import logging
 from qdev_wrappers.file_setup import my_init
 from qdev_wrappers.device_annotator.device_image import save_device_image
 from qdev_wrappers.show_num import show_num

--- a/qdev_wrappers/file_setup.py
+++ b/qdev_wrappers/file_setup.py
@@ -92,48 +92,6 @@ def _init_device_image(station):
     log.info('device image initialised')
 
 
-def _set_up_ipython_logging():
-    ipython = get_ipython()
-    # turn on logging only if in ipython
-    # else crash and burn
-    if ipython is None:
-        raise RuntimeWarning("History can't be saved. "
-                             "-Refusing to proceed (use IPython/jupyter)")
-    else:
-        exp_folder = CURRENT_EXPERIMENT["exp_folder"]
-        logfile = "{}{}".format(exp_folder, "commands.log")
-        CURRENT_EXPERIMENT['logfile'] = logfile
-        if not CURRENT_EXPERIMENT["logging_enabled"]:
-            log.debug("Logging commands to: t{}".format(logfile))
-            ipython.magic("%logstart -t -o {} {}".format(logfile, "append"))
-            CURRENT_EXPERIMENT["logging_enabled"] = True
-        else:
-            log.debug("Logging already started at {}".format(logfile))
-
-
-def init_python_logger() -> None:
-    """
-    This sets up logging to a time based logging.
-    This means that all logging messages on or above
-    filelogginglevel will be written to pythonlog.log
-    All logging messages on or above consolelogginglevel
-    will be written to stderr.
-    """
-    formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    filelogginglevel = logging.INFO
-    consolelogginglevel = qc.config.core.loglevel
-    ch = logging.StreamHandler()
-    ch.setLevel(consolelogginglevel)
-    ch.setFormatter(formatter)
-    fh1 = logging.handlers.TimedRotatingFileHandler('pythonlog.log', when='midnight')
-    fh1.setLevel(filelogginglevel)
-    fh1.setFormatter(formatter)
-    logging.basicConfig(handlers=[ch, fh1], level=logging.DEBUG)
-    # capture any warnings from the warnings module
-    logging.captureWarnings(capture=True)
-    logging.info("QCoDes python logger setup")
-
 def _set_up_pdf_preferences(subfolder_name: str = 'pdf', display_pdf=True,
                             display_individual_pdf=False):
     _set_up_subfolder(subfolder_name)

--- a/qdev_wrappers/file_setup.py
+++ b/qdev_wrappers/file_setup.py
@@ -5,9 +5,13 @@ from os.path import sep
 import logging
 import qcodes as qc
 import sys
+import warnings
 
 from qdev_wrappers.device_annotator.qcodes_device_annotator import DeviceImage
 from qdev_wrappers.configreader import Config
+from qdev_wrappers.logging.logging_functions import (
+    start_python_logger,
+    start_command_history_logger)
 
 log = logging.getLogger(__name__)
 CURRENT_EXPERIMENT = {}
@@ -15,6 +19,28 @@ CURRENT_EXPERIMENT["logging_enabled"] = False
 CURRENT_EXPERIMENT["init"] = False
 pdfdisplay = {}
 
+# aliases for keeping logging functions compatible
+def _set_up_ipython_logging():
+    warnings.warn("The function _set_up_ipython_logging is deprecated and " +
+                  "will be removed in the " +
+                  "future. For general logging simply import the wrappers " +
+                  "logging module via:\n" +
+                  ">>> from qdev_wrappers import logging\n" +
+                  "as the first line of your script.\n" +
+                  "For only command histroy logging call:\n"
+                  "start_command_history_logger")
+    start_command_history_logger()
+
+def init_python_logger() -> None:
+    warnings.warn("This function init_python_logger is deprecated and will " +
+                  "be removed in the " +
+                  "future. For general logging simply import the wrappers " +
+                  "logging module via:\n" +
+                  ">>> from qdev_wrappers import logging\n" +
+                  "as the first line of your script.\n" +
+                  "For only python logging call:\n"
+                  "start_python_logger")
+    start_python_logger()
 
 def close_station(station):
     for comp in station.components:

--- a/qdev_wrappers/logging/__init__.py
+++ b/qdev_wrappers/logging/__init__.py
@@ -1,0 +1,3 @@
+from qdev_wrappers.logging.logging_functions import start_logging
+
+start_logging()

--- a/qdev_wrappers/logging/logging_functions.py
+++ b/qdev_wrappers/logging/logging_functions.py
@@ -21,7 +21,10 @@ def start_python_logger() -> None:
     """
     formatter = logging.Formatter(
         '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    filelogginglevel = config.core.file_loglevel
+    try:
+        filelogginglevel = config.core.file_loglevel
+    except KeyError:
+        filelogginglevel = "Info"
     consolelogginglevel = config.core.loglevel
     ch = logging.StreamHandler()
     ch.setLevel(consolelogginglevel)

--- a/qdev_wrappers/logging/logging_functions.py
+++ b/qdev_wrappers/logging/logging_functions.py
@@ -1,0 +1,64 @@
+import logging
+import os
+from IPython import get_ipython
+from qcodes import config
+
+log = logging.getLogger(__name__)
+
+logging_dir = "logs"
+history_log_name = "history.log"
+python_log_name = 'pythonlog.log'
+
+
+def start_python_logger() -> None:
+    """
+    Logging of messages passed throug the python logging module
+    This sets up logging to a time based logging.
+    This means that all logging messages on or above
+    filelogginglevel will be written to pythonlog.log
+    All logging messages on or above consolelogginglevel
+    will be written to stderr.
+    """
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    filelogginglevel = config.core.file_loglevel
+    consolelogginglevel = config.core.loglevel
+    ch = logging.StreamHandler()
+    ch.setLevel(consolelogginglevel)
+    ch.setFormatter(formatter)
+    filename = os.path.join(config.user.mainfolder,
+                            logging_dir,
+                            python_log_name)
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+
+    fh1 = logging.handlers.TimedRotatingFileHandler(filename,
+                                                    when='midnight')
+    fh1.setLevel(filelogginglevel)
+    fh1.setFormatter(formatter)
+    logging.basicConfig(handlers=[ch, fh1], level=logging.DEBUG)
+    # capture any warnings from the warnings module
+    logging.captureWarnings(capture=True)
+    log.info("QCoDes python logger setup")
+
+
+def start_command_history_logger():
+    """
+    logging of the history of the interactive command shell
+    works only with ipython
+    """
+    ipython = get_ipython()
+    if ipython is None:
+        raise RuntimeError("History can't be saved. "
+                           "-Refusing to proceed (use IPython/jupyter)")
+    ipython.magic("%logstop")
+    filename = os.path.join(config.user.mainfolder,
+                            logging_dir,
+                            python_log_name)
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    ipython.magic("%logstart -t -o {} {}".format(filename, "append"))
+    log.info("Started logging IPython history")
+
+
+def start_logging():
+    start_python_logger()
+    start_command_history_logger()

--- a/qdev_wrappers/templates/initialisation_script.py
+++ b/qdev_wrappers/templates/initialisation_script.py
@@ -1,3 +1,6 @@
+# import as a first module logging, don't move this anywhere else!
+from qdev_wrappers import logging
+
 # import modules you might want to use
 import atexit
 import qcodes as qc
@@ -39,8 +42,6 @@ mpl.rcParams['font.size'] = 10
 
 
 if __name__ == '__main__':
-    # this line should be the first line, no matter what
-    init_python_logger()
     # make sure that all instrument connections are closed at shutdown
     atexit.register(qc.Instrument.close_all)
     # Close existing connections if present

--- a/qdev_wrappers/templates/qcodesrc.json
+++ b/qdev_wrappers/templates/qcodesrc.json
@@ -6,7 +6,8 @@
     },
     "core": {
         "default_fmt": "data/{date}/#{counter}_{name}_{time}",
-        "loglevel": "WARNING"
+        "loglevel": "WARNING",
+        "file_loglevel": "INFO"
     },
     "user": {
         "scriptfolder": "/Users/natalie/Documents/PhD/Qdev/QcodesRelated/QcodesExperiments/ExperimentScripts",

--- a/qdev_wrappers/templates/qcodesrc_schema.json
+++ b/qdev_wrappers/templates/qcodesrc_schema.json
@@ -47,7 +47,7 @@
                 },
                 "loglevel": {
                     "type": "string",
-                    "default": "DEBUG",
+                    "default": "INFO",
                     "description": "control logging  level",
                     "enum": [
                         "CRITICAL",
@@ -56,7 +56,20 @@
                         "INFO",
                         "DEBUG"
                     ]
+                },
+                "file_loglevel": {
+                    "type": "string",
+                    "default": "INFO",
+                    "description": "control logging level of log file",
+                    "enum": [
+                        "CRITICAL",
+                        "ERROR",
+                        "WARNING",
+                        "INFO",
+                        "DEBUG"
+                    ]
                 }
+
             },
             "description": "controls core settings of qcodes",
             "required": [


### PR DESCRIPTION
This is the first step towards disentangling the wrappers into modules. This module does not depend on anything else in the wrappers.
To use it simply add
```
from qdev_wrappers import logging
```
as the first line of your code. Log files will be created in a central directory (data directory from qcodesrc.json file/logs)