### PR TITLE
fix bug in analysis_plot_helpers save_fig function

### DIFF
--- a/qdev_wrappers/transmon/analysis_plot_helpers.py
+++ b/qdev_wrappers/transmon/analysis_plot_helpers.py
@@ -205,8 +205,10 @@ def save_fig(plot_to_save, name='analysis', counter=None, pulse=False):
     if counter is None and name is 'analysis':
         raise AttributeError('No name or counter specified will result'
                              ' in non unique plot name')
-
-    full_name = '{0:03d}'.format(counter) + '_' + name + '.png'
+    elif counter is None:
+        full_name = name + '.png'
+    else:
+        full_name = '{0:03d}'.format(counter) + '_' + name + '.png'
 
     if pulse:
         location = get_pulse_location()


### PR DESCRIPTION
Changes the logic for generating name to save analysis plots under. This use to require the provision of the dataset number that the analysis came from and would break if you didn't provide one. You can now instead provide a custom name. Literally just fixes something broken which is only used by my own automated analysis plotting.