### PR TITLE
pass the name explicitly passing of name

### DIFF
--- a/qdev_wrappers/station_configurator.py
+++ b/qdev_wrappers/station_configurator.py
@@ -125,7 +125,7 @@ class StationConfigurator:
         for k, v in kwargs:
             init_kwargs[k] = v
 
-        instr = instr_class(identifier, **init_kwargs)
+        instr = instr_class(name=identifier, **init_kwargs)
         # setup
 
         # local function to refactor common code from defining new parameter


### PR DESCRIPTION
This will work even if the config is used for a channel where name is not the first arg 
@Dominik-Vogel 