### PR TITLE
fix option for having parameters without an instrument

### DIFF
--- a/qdev_wrappers/sweep_functions.py
+++ b/qdev_wrappers/sweep_functions.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 from os.path import sep
 from typing import Optional, Tuple, Sequence
 from collections import Iterable
+from contextlib import suppress
 from pyqtgraph.multiprocess.remoteproxy import ClosedError
 
 import qcodes as qc
@@ -17,7 +18,6 @@ from qdev_wrappers.plot_functions import _plot_setup, \
     _save_individual_plots
 from qdev_wrappers.device_annotator.device_image import save_device_image
 
-
 import logging
 log = logging.getLogger(__name__)
 
@@ -30,16 +30,11 @@ def _flush_buffers(*params):
     Supposed to be called inside doNd like so:
     _flush_buffers(inst_set, *inst_meas)
     """
-    instrument_names = set()
-    for param in params:
-        if hasattr(param, '_instrument'):
-            instrument_names.add(param._instrument.root_instrument.name)
-        elif isinstance(param, VisaInstrument):
-            instrument_names.add(param.root_instrument.name)
-
-    for name in instrument_names:
+    for name in set(p.root_instrument.name
+                    for p in params
+                    if p.root_instrument is not None):
         instr = qc.Instrument.find_instrument(name)
-        if isinstance(instr, qc.VisaInstrument):
+        with suppress(AttributeError):
             instr.device_clear()
 
 

--- a/qdev_wrappers/sweep_functions.py
+++ b/qdev_wrappers/sweep_functions.py
@@ -30,10 +30,13 @@ def _flush_buffers(*params):
     Supposed to be called inside doNd like so:
     _flush_buffers(inst_set, *inst_meas)
     """
-    for name in set(p.root_instrument.name
-                    for p in params
-                    if p.root_instrument is not None):
+    instr_names = set(p.root_instrument.name
+                      for p in params
+                      if p.root_instrument is not None)
+    for name in instr_names:
         instr = qc.Instrument.find_instrument(name)
+        # suppress for non visa instruments, that do not implement this
+        # method
         with suppress(AttributeError):
             instr.device_clear()
 


### PR DESCRIPTION
As of now there is a missing check for `parameter._instrument is not None` to prevent the `device_clear` from being called for a parameter that does not have an associated instrument.

Tested with
```
from qdev_wrappers.logger import start_logging
start_logging()
import qcodes as qc
from qdev_wrappers.sweep_functions import do2d
from qdev_wrappers.file_setup import CURRENT_EXPERIMENT
from qdev_wrappers.station_configurator import StationConfigurator

CURRENT_EXPERIMENT['sample_name'] = 'bs'
CURRENT_EXPERIMENT['plot_x_position'] = 0
CURRENT_EXPERIMENT['logfile'] = 'bs.log'


sc = StationConfigurator()
dmm = sc.load_instrument('keysightdmm_right')
p1 = qc.Parameter('outp', set_cmd=None)
do2d(p1, 0.,1.,3,0,p1,0.,1.,3,0,p1, dmm.volt)
```