### PR TITLE
Znb

### DIFF
--- a/qdev_wrappers/customised_instruments/ZNB_ext.py
+++ b/qdev_wrappers/customised_instruments/ZNB_ext.py
@@ -72,13 +72,14 @@ class ZNB_ext(ZNB):
 
         if S21:
             self.add_channel(channel_name='S21')
+            self.channels.autoscale()
         if spec_mode:
             if gen_address is not None:
                 self.add_spectroscopy_channel(gen_address)
             else:
                 log.warning('spec mode not added as ' +
                             'no generator ip address provided')
-        self.channels.autoscale()
+            self.channels.autoscale()
 
 
     # spectroscopy

--- a/qdev_wrappers/customised_instruments/ZNB_ext.py
+++ b/qdev_wrappers/customised_instruments/ZNB_ext.py
@@ -76,10 +76,10 @@ class ZNB_ext(ZNB):
         if spec_mode:
             if gen_address is not None:
                 self.add_spectroscopy_channel(gen_address)
+                self.channels.autoscale()
             else:
                 log.warning('spec mode not added as ' +
                             'no generator ip address provided')
-            self.channels.autoscale()
 
 
     # spectroscopy

--- a/qdev_wrappers/customised_instruments/ZNB_ext.py
+++ b/qdev_wrappers/customised_instruments/ZNB_ext.py
@@ -72,11 +72,9 @@ class ZNB_ext(ZNB):
 
         if S21:
             self.add_channel(channel_name='S21')
-            self.channels.autoscale()
         if spec_mode:
             if gen_address is not None:
                 self.add_spectroscopy_channel(gen_address)
-                self.channels.autoscale()
             else:
                 log.warning('spec mode not added as ' +
                             'no generator ip address provided')


### PR DESCRIPTION
Move `self.channels.autoscale()` inside `if` statements so that it is only called if channels are created. Previously autoscale would throw an error if ZNB is initialized with no channels.

@Dominik-Vogel can you take a quick look? Should be fast to merge.