### PR TITLE
Added commit hash to snapshot using the ConfigComponent class.

### DIFF
--- a/qdev_wrappers/station_configurator.py
+++ b/qdev_wrappers/station_configurator.py
@@ -77,17 +77,6 @@ class StationConfigurator:
                 
                 hashlist = []
                 try:
-<<<<<<< HEAD
-                    gitloc = os.path.abspath(qcodes.config.user.codebase)
-                    gits = [os.path.join(gitloc, dn) for dn in os.listdir( gitloc) if os.path.isdir(os.path.join( gitloc, dn, '.git'))]
-
-                    for gitloc in gits:
-                        try:
-                            ghash = subprocess.check_output([gitcmd, r'-C', gitloc, 'rev-parse', '--verify', 'HEAD'])
-                        except:
-                            pass
-                        hashlist.append(ghash.rstrip().decode("utf-8"))
-=======
                     cbroot = os.path.abspath(qcodes.config.user.codebase)
                     repolist = [dn for dn in os.listdir(cbroot) if os.path.isdir(os.path.join(cbroot, dn, '.git'))]
 
@@ -98,7 +87,6 @@ class StationConfigurator:
                         except:
                             pass
                         hashlist.append(reponame + ":" +ghash.rstrip().decode("utf-8"))
->>>>>>> 61bb80f49b74dbfbda560b8c67e6e893eb90d382
                 except KeyError:
                     pass
                 return hashlist

--- a/qdev_wrappers/station_configurator.py
+++ b/qdev_wrappers/station_configurator.py
@@ -95,7 +95,7 @@ class StationConfigurator:
                             gstatus = gstatus.rstrip().decode("utf-8") # turn \n terminated byte-array into str
                             if gstatus != '':
                                 gstatus = gstatus.split('\n') # turn \n-separated str into list of str
-                                warnings.warn('Active branch ({}) is {} commit(s) ahead of its origin}'.format(gbranch, len(gstatus)), RuntimeWarning)
+                                warnings.warn('Active branch ({}) is {} commit(s) ahead of its origin'.format(gbranch, len(gstatus)), RuntimeWarning)
                         except:
                             pass
                         hashlist.append(reponame + ":" +ghash.rstrip().decode("utf-8"))

--- a/qdev_wrappers/station_configurator.py
+++ b/qdev_wrappers/station_configurator.py
@@ -92,7 +92,6 @@ class StationConfigurator:
                                 warnings.warn('Active branch of {} is not master, but {}'.format(reponame, gbranch), RuntimeWarning)
                             
                             gstatus = subprocess.check_output([gitcmd, r'-C', repoloc, 'rev-list', gbranch, '--not', 'origin/'+gbranch])
-                            print(gstatus)
                             
                         except:
                             pass

--- a/qdev_wrappers/station_configurator.py
+++ b/qdev_wrappers/station_configurator.py
@@ -5,6 +5,7 @@ import logging
 import yaml
 import os
 import subprocess
+import warnings
 from copy import deepcopy
 import qcodes
 from qcodes.instrument.base import Instrument
@@ -84,6 +85,15 @@ class StationConfigurator:
                         try:
                             repoloc = os.path.join(cbroot, reponame)
                             ghash = subprocess.check_output([gitcmd, r'-C', repoloc, 'rev-parse', '--verify', 'HEAD'])
+
+                            gbranch = subprocess.check_output([gitcmd, r'-C', repoloc, 'rev-parse', '--abbrev-ref', 'HEAD'])
+                            gbranch = gbranch.rstrip().decode("utf-8")
+                            if gbranch != 'master':
+                                warnings.warn('Active branch of {} is not master, but {}'.format(reponame, gbranch), RuntimeWarning)
+                            
+                            gstatus = subprocess.check_output([gitcmd, r'-C', repoloc, 'rev-list', gbranch, '--not', 'origin/'+gbranch])
+                            print(gstatus)
+                            
                         except:
                             pass
                         hashlist.append(reponame + ":" +ghash.rstrip().decode("utf-8"))

--- a/qdev_wrappers/station_configurator.py
+++ b/qdev_wrappers/station_configurator.py
@@ -92,7 +92,10 @@ class StationConfigurator:
                                 warnings.warn('Active branch of {} is not master, but {}'.format(reponame, gbranch), RuntimeWarning)
                             
                             gstatus = subprocess.check_output([gitcmd, r'-C', repoloc, 'rev-list', gbranch, '--not', 'origin/'+gbranch])
-                            
+                            gstatus = gstatus.rstrip().decode("utf-8") # turn \n terminated byte-array into str
+                            if gstatus != '':
+                                gstatus = gstatus.split('\n') # turn \n-separated str into list of str
+                                warnings.warn('Active branch ({}) is {} commit(s) ahead of its origin}'.format(gbranch, len(gstatus)), RuntimeWarning)
                         except:
                             pass
                         hashlist.append(reponame + ":" +ghash.rstrip().decode("utf-8"))

--- a/qdev_wrappers/sweep_functions.py
+++ b/qdev_wrappers/sweep_functions.py
@@ -182,27 +182,31 @@ def _do_MatPlot(data,meas_params):
     plot.rescale_axis()
     plot.fig.tight_layout(pad=3)
 
+    dsid = DataSet.location_provider.counter
+    exp_root = sep.join([CURRENT_EXPERIMENT["mainfolder"], CURRENT_EXPERIMENT["sample_name"]])
+
     if 'pdf_subfolder' in CURRENT_EXPERIMENT:
-        title_list = plot.get_default_title().split(sep)
-        title_list.insert(-1, CURRENT_EXPERIMENT['pdf_subfolder'])
-        title = sep.join(title_list)
-        plot.save("{}.pdf".format(title))
+        # title_list = plot.get_default_title().split(sep)
+        # title_list.insert(-1, CURRENT_EXPERIMENT['pdf_subfolder'])
+        # title = sep.join(title_list)
+        
+        figfn = sep.join([exp_root, CURRENT_EXPERIMENT["pdf_subfolder"], '{:03d}'.format(dsid)])
+        plot.save("{}.pdf".format(figfn))
 
     if 'png_subfolder' in CURRENT_EXPERIMENT:
-        title_list = plot.get_default_title().split(sep)
-        title_list.insert(-1, CURRENT_EXPERIMENT['png_subfolder'])
-        title = sep.join(title_list)
-        plot.fig.savefig("{}.png".format(title),dpi=500)
+        figfn = sep.join([exp_root, CURRENT_EXPERIMENT["png_subfolder"], '{:03d}'.format(dsid)])
+        plot.fig.savefig("{}.png".format(figfn),dpi=500)
 
     if (pdfdisplay['combined'] or
             (num_subplots == 1 and pdfdisplay['individual'])):
         plot.fig.canvas.draw()
-        plt.show()
+        # plt.show()
     else:
         plt.close(plot.fig)
     if num_subplots > 1:
         _save_individual_plots(data, meas_params,
                                pdfdisplay['individual'])
+    # plt.close()
     plt.ion()
 
 


### PR DESCRIPTION
When (re-)initializing qcodes such that changes in whatever modules are incorporated into the workflow, the class ConfigComponent is called once. 
I think the initialization method of this class is a rather logical point to query the git commit hashes and add them to the metadata. In fact, by adding the information to the  ConfigComponent.data['codebase']  attribute, the information also ends up at a logical point in the metadata dict. 

To query the git commit hashes, we look into qcodes.config.user.codebase, for the folder that contains qcodes related repositories. When there is no such config key, the ConfigComponent.data['codebase'] will simply contain a empty list. 

The location of the git executable can be specified by setting qcodes.config.core.gitpath. When there is no such key, we will fall back to the Git for Window default location.