### PR TITLE
StationConfigurator: tab completion for loading instruments from yaml file

### DIFF
--- a/qdev_wrappers/station_configurator.py
+++ b/qdev_wrappers/station_configurator.py
@@ -1,5 +1,6 @@
 from contextlib import suppress
 from typing import Optional
+from functools import partial
 import importlib
 import logging
 import yaml
@@ -43,6 +44,11 @@ class StationConfigurator:
         self.filename = filename
 
         self.load_file(self.filename)
+        for instrument_name in self._instrument_config.keys():
+            # TODO: check if name is valid (does not start with digit, contain
+            # dot, other signs etc.)
+            setattr(self, f'load_{instrument_name}',
+                    partial(self.load_instrument, identifier=instrument_name))
 
     def load_file(self, filename: Optional[str] = None):
         if filename is None:

--- a/qdev_wrappers/station_configurator.py
+++ b/qdev_wrappers/station_configurator.py
@@ -47,8 +47,16 @@ class StationConfigurator:
         for instrument_name in self._instrument_config.keys():
             # TODO: check if name is valid (does not start with digit, contain
             # dot, other signs etc.)
-            setattr(self, f'load_{instrument_name}',
-                    partial(self.load_instrument, identifier=instrument_name))
+            method_name = f'load_{instrument_name}'
+            if method_name.isidentifier():
+                setattr(self, method_name,
+                        partial(self.load_instrument,
+                                identifier=instrument_name))
+            else:
+                log.warning(f'Invalid identifier: ' +
+                            f'for the instrument {instrument_name} no ' +
+                            f'lazy loading method {method_name} could be ' +
+                            'created in the StationConfigurator')
 
     def load_file(self, filename: Optional[str] = None):
         if filename is None:


### PR DESCRIPTION
With this PR methods are added to the station configurator, that are called `load_<instrument_name>` where `instrument_name` is an instrument that is defined in the yaml file. With this you can do
```
from qdev_wrappers.station_configurator import StationConfigurator
sc = StationConfigurator()
# type sc.load_<tab> and tab complete to get
sc.load_AWG5014()
```
also kwargs can be passed on.