### PR TITLE
Hotfix SR86x_ext

### DIFF
--- a/qdev_wrappers/customised_instruments/SR86x_ext.py
+++ b/qdev_wrappers/customised_instruments/SR86x_ext.py
@@ -36,13 +36,13 @@ class SR86x_ext(SR86x):
 
     def _get_conductance(self):
         V = self.amplitude.get_latest()
-        I = self.R()/self.iv_gain.get_latest()
+        I = abs(self.R()/self.iv_gain.get_latest())
         conductance_quantum = 7.7480917310e-5
         return (I/V)/conductance_quantum
 
     def _get_resistance(self):
         V = self.amplitude.get_latest()
-        I = self.R()/self.iv_gain.get_latest()
+        I = abs(self.R()/self.iv_gain.get_latest())
         return (V/I)
 
     def _get_conductance_X(self):


### PR DESCRIPTION
Wrong sign for resistance and conductance with negative IV gain.