### PR TITLE
Switch to Ruamel in stationconfigurator

### DIFF
--- a/qdev_wrappers/station_configurator.py
+++ b/qdev_wrappers/station_configurator.py
@@ -3,7 +3,6 @@ from typing import Optional
 from functools import partial
 import importlib
 import logging
-from ruamel.yaml import YAML
 import os
 from copy import deepcopy
 import qcodes
@@ -13,6 +12,15 @@ import qcodes.utils.validators as validators
 from qcodes.instrument.parameter import Parameter
 from qcodes.monitor.monitor import Monitor
 from .parameters import DelegateParameter
+use_pyyaml = False
+try:
+    from ruamel.yaml import YAML
+except ImportError:
+    import yaml
+    use_pyyaml = True
+    warnings.warn("ruamel yaml not found station configurator is falling back to pyyaml. "
+                           "It's highly recommended to install ruamel.yaml. This fixes issues with "
+                           "scientific notation and duplicate instruments in the YAML file")
 
 log = logging.getLogger(__name__)
 
@@ -59,7 +67,8 @@ class StationConfigurator:
                             'created in the StationConfigurator')
 
     def load_file(self, filename: Optional[str] = None):
-        yaml=YAML()
+        if use_pyyaml = False:
+                yaml=YAML()
         if filename is None:
             filename = default_file
         try:

--- a/qdev_wrappers/station_configurator.py
+++ b/qdev_wrappers/station_configurator.py
@@ -3,7 +3,7 @@ from typing import Optional
 from functools import partial
 import importlib
 import logging
-import yaml
+from ruamel.yaml import YAML
 import os
 from copy import deepcopy
 import qcodes
@@ -59,6 +59,7 @@ class StationConfigurator:
                             'created in the StationConfigurator')
 
     def load_file(self, filename: Optional[str] = None):
+        yaml=YAML()
         if filename is None:
             filename = default_file
         try:

--- a/qdev_wrappers/station_configurator.py
+++ b/qdev_wrappers/station_configurator.py
@@ -3,6 +3,7 @@ from typing import Optional
 from functools import partial
 import importlib
 import logging
+import warnings
 import os
 from copy import deepcopy
 import qcodes
@@ -16,7 +17,6 @@ use_pyyaml = False
 try:
     from ruamel.yaml import YAML
 except ImportError:
-    import yaml
     use_pyyaml = True
     warnings.warn("ruamel yaml not found station configurator is falling back to pyyaml. "
                            "It's highly recommended to install ruamel.yaml. This fixes issues with "
@@ -67,8 +67,10 @@ class StationConfigurator:
                             'created in the StationConfigurator')
 
     def load_file(self, filename: Optional[str] = None):
-        if use_pyyaml = False:
-                yaml=YAML()
+        if use_pyyaml:
+            import yaml
+        else:
+            yaml=YAML()
         if filename is None:
             filename = default_file
         try:


### PR DESCRIPTION
Still having problems with scientific notation in yaml file (@Dominik-Vogel this works for some instruments if the parameter has get_parser=float unfortunately this is not the case for all instruments).
Ended up spending 5 min looking into ruamel and it works right out of the box now with scientific notation! Also the duplicate error message is extremely well done (tested it on T3 and found I had a duplicate in a set of parameters).

@Dominik-Vogel or @jenshnielsen can you follow up on this? It is tested and works on T3 with full cQED and transport set of instruments. However, this pull request is missing some parts for installing ruamel.yaml instead of pyyaml when installing qdev-wrappers.

Fixes #110.
