### PR TITLE
Add offset as parameter_attribute in SCFG

### DIFF
--- a/qdev_wrappers/station_configurator.py
+++ b/qdev_wrappers/station_configurator.py
@@ -40,11 +40,12 @@ class StationConfigurator:
     """
 
     PARAMETER_ATTRIBUTES = ['label', 'unit', 'scale', 'inter_delay', 'delay',
-                            'step']
+                            'step', 'offset']
 
     def __init__(self, filename: Optional[str] = None,
                  station: Optional[Station] = None) -> None:
         self.monitor_parameters = {}
+        self.monitor = Monitor()
 
         if station is None:
             station = Station.default or Station()
@@ -217,6 +218,6 @@ class StationConfigurator:
         self.station.add_component(instr)
 
         # restart Monitor
-        Monitor(*self.monitor_parameters.values())
+        self.monitor = Monitor(*self.monitor_parameters.values())
 
         return instr

--- a/qdev_wrappers/station_configurator.py
+++ b/qdev_wrappers/station_configurator.py
@@ -45,7 +45,6 @@ class StationConfigurator:
     def __init__(self, filename: Optional[str] = None,
                  station: Optional[Station] = None) -> None:
         self.monitor_parameters = {}
-        self.monitor = Monitor()
 
         if station is None:
             station = Station.default or Station()
@@ -218,6 +217,6 @@ class StationConfigurator:
         self.station.add_component(instr)
 
         # restart Monitor
-        self.monitor = Monitor(*self.monitor_parameters.values())
+        Monitor(*self.monitor_parameters.values())
 
         return instr


### PR DESCRIPTION
@Dominik-Vogel by chance I discovered my issue with `monitor.update_all()`. My problem was I didn't call it from the initialized monitor object. With this change one can do `scfg.monitor.update_all()`.

Also added `offset` to the list of parameter attributes.
