### PR TITLE
Alazar measuring only Channel A

### DIFF
--- a/qdev_wrappers/alazar_controllers/ATSChannelController.py
+++ b/qdev_wrappers/alazar_controllers/ATSChannelController.py
@@ -48,7 +48,10 @@ class ATSChannelController(AcquisitionController):
         super().__init__(name, alazar_name, **kwargs)
         self.filter_settings = {'filter': self.filter_dict[filter],
                                 'numtaps': numtaps}
-        self.number_of_channels = 2
+        if self._get_alazar().channel_selection() in ['A']:
+            self.number_of_channels = 1
+        else:
+            self.number_of_channels = 2
 
         channels = ChannelList(self, "Channels", AlazarChannel,
                                multichan_paramclass=AlazarMultiChannelParameter)
@@ -287,7 +290,8 @@ class ATSChannelController(AcquisitionController):
                                            samples_per_record,
                                            self.number_of_channels)
         channelAData = reshaped_buf[..., 0]
-        channelBData = reshaped_buf[..., 1]
+        if self.number_of_channels == 2:
+            channelBData = reshaped_buf[..., 1]
 
         def handle_alazar_channel(channelData,
                                   channel_number: int,


### PR DESCRIPTION
There are issues with memory being cleared fast enough when we want to measure continuously. This PR allows to only measure channel A cutting the amount of data to be handled by 2.

This is really only a fix and should probably be done correctly at a later point (this will not work for channel B with the way the alazar_channels are set up). This is also not dynamic so if one changes the number of channels on alazar then one needs to manually update alazar channel controller accordingly.

@jenshnielsen 