### PR TITLE
Smart color scale

### DIFF
--- a/qdev_wrappers/plot_functions.py
+++ b/qdev_wrappers/plot_functions.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 from os.path import sep
 from copy import deepcopy
 import functools
@@ -10,12 +11,26 @@ from qcodes.plots.qcmatplotlib import MatPlot
 from qdev_wrappers.file_setup import CURRENT_EXPERIMENT
 from qcodes.instrument.channel import MultiChannelInstrumentParameter
 
-def auto_range_iqr(data_array):
+
+def auto_range_iqr(data_array: np.ndarray) -> Tuple[float, float]:
+    """
+    Get the min and max range of the provided array that excludes outliers
+    following the IQR rule.
+
+    This function computes the inter-quartile-range (IQR), defined by Q3-Q1,
+    i.e. the percentiles for 75% and 25% of the destribution. The region
+    without outliers is defined by [Q1-1.5*IQR, Q3+1.5*IQR].
+    Args:
+        data_array: numpy array of arbitrary dimension containing the
+            statistical data
+    returns:
+        vmin, vmax: region limits [vmin, vmax]
+    """
     z = data_array.flatten()
     zmax = z.max()
     zmin = z.min()
     zrange = zmax-zmin
-    q3, q1 = np.percentile(z, [75 ,25])
+    q3, q1 = np.percentile(z, [75, 25])
     IQR = q3-q1
     # handle corner case of all data zero, such that IQR is zero
     # to counter numerical artifacts do not test IQR == 0, but IQR on its

--- a/qdev_wrappers/plot_functions.py
+++ b/qdev_wrappers/plot_functions.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 import functools
 from matplotlib import ticker
 import matplotlib.pyplot as plt
+import numpy as np
 
 from qcodes.plots.pyqtgraph import QtPlot
 from qcodes.plots.qcmatplotlib import MatPlot
@@ -65,8 +66,12 @@ def _plot_setup(data, inst_meas, useQT=True, startranges=None):
             if 'z' in inst_meta_data:
                 xlen, ylen = inst_meta_data['z'].shape
                 rasterized = xlen * ylen > 5000
-                plot.add(inst_meas_data, subplot=j + k + 1,
-                         rasterized=rasterized)
+                po = plot.add(inst_meas_data, subplot=j + k + 1,
+                              rasterized=rasterized)
+                z = inst_meta_data['z']
+                vmin = np.percentile(z, 99)
+                vmax = np.percentile(z, 1)
+                po.set_clim(vmin=vmin, vmax=vmax)
             else:
                 rasterized = False
                 plot.add(inst_meas_data, subplot=j + k + 1, color=color)

--- a/qdev_wrappers/plot_functions.py
+++ b/qdev_wrappers/plot_functions.py
@@ -10,6 +10,27 @@ from qcodes.plots.qcmatplotlib import MatPlot
 from qdev_wrappers.file_setup import CURRENT_EXPERIMENT
 from qcodes.instrument.channel import MultiChannelInstrumentParameter
 
+def auto_range_iqr(data_array):
+    z = data_array.flatten()
+    zmax = z.max()
+    zmin = z.min()
+    zrange = zmax-zmin
+    q3, q1 = np.percentile(z, [75 ,25])
+    IQR = q3-q1
+    # handle corner case of all data zero, such that IQR is zero
+    # to counter numerical artifacts do not test IQR == 0, but IQR on its
+    # natural scale (zrange) to be smaller than some very small number.
+    # also test for zrange to be 0.0 to avoid division by 0.
+    # all This is possibly to careful...
+    if zrange == 0.0 or IQR/zrange < 1e-8:
+        vmin = zmin
+        vmax = zmax
+    else:
+        vmin = max(q1 - 1.5*IQR, zmin)
+        vmax = min(q3 + 1.5*IQR, zmax)
+    return vmin, vmax
+
+
 def _plot_setup(data, inst_meas, useQT=True, startranges=None):
     title = "{} #{:03d}".format(CURRENT_EXPERIMENT["sample_name"],
                                 data.location_provider.counter)
@@ -68,24 +89,7 @@ def _plot_setup(data, inst_meas, useQT=True, startranges=None):
                 rasterized = xlen * ylen > 5000
                 po = plot.add(inst_meas_data, subplot=j + k + 1,
                               rasterized=rasterized)
-                z = inst_meta_data['z'].flatten()
-                zmax = z.max()
-                zmin = z.min()
-                zrange = zmax-zmin
-                q3, q1 = np.percentile(z, [75 ,25])
-                IQR = q3-q1
-                print(f'q3 is {q3}, q1: {q1}')
-                # handle corner case of all data zero, such that IQR is zero
-                # to counter numerical artifacts do not test IQR == 0, but IQR on its
-                # natural scale (zrange) to be smaller than some very small number.
-                # also test for zrange to be 0.0 to avoid division by 0.
-                # all This is possibly to careful...
-                if zrange == 0.0 or IQR/zrange < 1e-8:
-                    vmin = zmin
-                    vmax = zmax
-                else:
-                    vmin = max(q1 - 1.5*IQR, zmin)
-                    vmax = min(q3 + 1.5*IQR, zmax)
+                vmin, vmax = auto_range_iqr(inst_meta_data['z'])
                 po.set_clim(vmin=vmin, vmax=vmax)
             else:
                 rasterized = False

--- a/qdev_wrappers/plot_functions.py
+++ b/qdev_wrappers/plot_functions.py
@@ -10,40 +10,8 @@ from qcodes.plots.pyqtgraph import QtPlot
 from qcodes.plots.qcmatplotlib import MatPlot
 from qdev_wrappers.file_setup import CURRENT_EXPERIMENT
 from qcodes.instrument.channel import MultiChannelInstrumentParameter
+from qcodes.utils.plotting import auto_range_iqr
 
-
-def auto_range_iqr(data_array: np.ndarray) -> Tuple[float, float]:
-    """
-    Get the min and max range of the provided array that excludes outliers
-    following the IQR rule.
-
-    This function computes the inter-quartile-range (IQR), defined by Q3-Q1,
-    i.e. the percentiles for 75% and 25% of the destribution. The region
-    without outliers is defined by [Q1-1.5*IQR, Q3+1.5*IQR].
-    Args:
-        data_array: numpy array of arbitrary dimension containing the
-            statistical data
-    returns:
-        vmin, vmax: region limits [vmin, vmax]
-    """
-    z = data_array.flatten()
-    zmax = z.max()
-    zmin = z.min()
-    zrange = zmax-zmin
-    q3, q1 = np.percentile(z, [75, 25])
-    IQR = q3-q1
-    # handle corner case of all data zero, such that IQR is zero
-    # to counter numerical artifacts do not test IQR == 0, but IQR on its
-    # natural scale (zrange) to be smaller than some very small number.
-    # also test for zrange to be 0.0 to avoid division by 0.
-    # all This is possibly to careful...
-    if zrange == 0.0 or IQR/zrange < 1e-8:
-        vmin = zmin
-        vmax = zmax
-    else:
-        vmin = max(q1 - 1.5*IQR, zmin)
-        vmax = min(q3 + 1.5*IQR, zmax)
-    return vmin, vmax
 
 
 def _plot_setup(data, inst_meas, useQT=True, startranges=None):

--- a/qdev_wrappers/plot_functions.py
+++ b/qdev_wrappers/plot_functions.py
@@ -11,10 +11,13 @@ from qcodes.plots.qcmatplotlib import MatPlot
 from qdev_wrappers.file_setup import CURRENT_EXPERIMENT
 from qcodes.instrument.channel import MultiChannelInstrumentParameter
 from qcodes.utils.plotting import auto_range_iqr
+from qcodes import config
 
 
-
-def _plot_setup(data, inst_meas, useQT=True, startranges=None):
+def _plot_setup(data, inst_meas, useQT=True, startranges=None,
+                smart_colorscale=None):
+    # default values
+    smart_colorscale = smart_colorscale or config.gui.smart_colorscale
     title = "{} #{:03d}".format(CURRENT_EXPERIMENT["sample_name"],
                                 data.location_provider.counter)
     rasterized_note = " rasterized plot"
@@ -42,6 +45,7 @@ def _plot_setup(data, inst_meas, useQT=True, startranges=None):
             j: The current sub-measurement
             k: -
         """
+
         color = 'C' + str(counter_two)
         if issubclass(i.__class__, MultiChannelInstrumentParameter) or i._instrument is None:
             inst_meas_name = name
@@ -72,8 +76,9 @@ def _plot_setup(data, inst_meas, useQT=True, startranges=None):
                 rasterized = xlen * ylen > 5000
                 po = plot.add(inst_meas_data, subplot=j + k + 1,
                               rasterized=rasterized)
-                vmin, vmax = auto_range_iqr(inst_meta_data['z'])
-                po.set_clim(vmin=vmin, vmax=vmax)
+                if smart_colorscale:
+                    vmin, vmax = auto_range_iqr(inst_meta_data['z'])
+                    po.set_clim(vmin=vmin, vmax=vmax)
             else:
                 rasterized = False
                 plot.add(inst_meas_data, subplot=j + k + 1, color=color)

--- a/qdev_wrappers/show_num.py
+++ b/qdev_wrappers/show_num.py
@@ -8,6 +8,7 @@ from qdev_wrappers.file_setup import CURRENT_EXPERIMENT
 from qcodes.utils.plotting import auto_range_iqr
 from qcodes.plots.pyqtgraph import QtPlot
 from qcodes.plots.qcmatplotlib import MatPlot
+from qcodes import config
 
 def check_experiment_is_initialized():
     if not getattr(CURRENT_EXPERIMENT, "init", True): 
@@ -18,7 +19,7 @@ def check_experiment_is_initialized():
 def show_num(ids, samplefolder=None, useQT=False, avg_sub='',
              do_plots=True, savepng=True, fig_size=[6,4], clim=None,
              dataname=None, xlim=None, ylim=None, transpose=False,
-             auto_color_scale=True, **kwargs):
+             smart_colorscale=None, **kwargs):
     """
     Show and return plot and data.
     Args:
@@ -40,7 +41,9 @@ def show_num(ids, samplefolder=None, useQT=False, avg_sub='',
         data, plots : returns the plots and the datasets
 
     """
-    
+    # default values
+    smart_colorscale = smart_colorscale or config.gui.smart_colorscale
+
     if not isinstance(ids, collections.Iterable):
         ids = (ids,)
 
@@ -51,6 +54,7 @@ def show_num(ids, samplefolder=None, useQT=False, avg_sub='',
     if samplefolder==None:
         check_experiment_is_initialized()
         samplefolder = qc.DataSet.location_provider.fmt.format(counter='')
+
 
     # Load all datasets into list
     for id in ids:
@@ -112,7 +116,7 @@ def show_num(ids, samplefolder=None, useQT=False, avg_sub='',
                         xlims[1].append(np.nanmax(arrays.set_arrays[1]))
                         ylims[0].append(np.nanmin(arrays.set_arrays[0]))
                         ylims[1].append(np.nanmax(arrays.set_arrays[0]))
-                        if auto_color_scale:
+                        if smart_colorscale:
                             clims[0], clims[1] = auto_range_iqr(arrays.ndarray)
                         else:
                             clims[0].append(np.nanmin(arrays.ndarray))

--- a/qdev_wrappers/show_num.py
+++ b/qdev_wrappers/show_num.py
@@ -5,6 +5,7 @@ import collections
 import matplotlib.pyplot as plt
 
 from qdev_wrappers.file_setup import CURRENT_EXPERIMENT
+from qdev_wrappers.plot_functions import auto_range_iqr
 from qcodes.plots.pyqtgraph import QtPlot
 from qcodes.plots.qcmatplotlib import MatPlot
 
@@ -14,8 +15,10 @@ def check_experiment_is_initialized():
                            "use qc.Init(mainfolder, samplename)")
 
 
-def show_num(ids, samplefolder=None,useQT=False,avg_sub='',do_plots=True,savepng=True,
-            fig_size=[6,4],clim=None,dataname=None,xlim=None,ylim=None,transpose=False,**kwargs):
+def show_num(ids, samplefolder=None, useQT=False, avg_sub='',
+             do_plots=True, savepng=True, fig_size=[6,4], clim=None,
+             dataname=None, xlim=None, ylim=None, transpose=False,
+             auto_color_scale=True, **kwargs):
     """
     Show and return plot and data.
     Args:
@@ -109,8 +112,11 @@ def show_num(ids, samplefolder=None,useQT=False,avg_sub='',do_plots=True,savepng
                         xlims[1].append(np.nanmax(arrays.set_arrays[1]))
                         ylims[0].append(np.nanmin(arrays.set_arrays[0]))
                         ylims[1].append(np.nanmax(arrays.set_arrays[0]))
-                        clims[0].append(np.nanmin(arrays.ndarray))
-                        clims[1].append(np.nanmax(arrays.ndarray))
+                        if auto_color_scale:
+                            clims[0], clims[1] = auto_range_iqr(arrays.ndarray)
+                        else:
+                            clims[0].append(np.nanmin(arrays.ndarray))
+                            clims[1].append(np.nanmax(arrays.ndarray))
                     else:
                         xlims[0].append(np.nanmin(arrays.set_arrays[0]))
                         xlims[1].append(np.nanmax(arrays.set_arrays[0]))

--- a/qdev_wrappers/show_num.py
+++ b/qdev_wrappers/show_num.py
@@ -5,7 +5,7 @@ import collections
 import matplotlib.pyplot as plt
 
 from qdev_wrappers.file_setup import CURRENT_EXPERIMENT
-from qdev_wrappers.plot_functions import auto_range_iqr
+from qcodes.utils.plotting import auto_range_iqr
 from qcodes.plots.pyqtgraph import QtPlot
 from qcodes.plots.qcmatplotlib import MatPlot
 


### PR DESCRIPTION
This PR adds an automatic color scaling for saved heatmap images (using doNd). All the 1% of the lowest and highest values will be represented in the same color (each). This means that outliers as long as they make up less than 1% of the data will be suppressed.

![017](https://user-images.githubusercontent.com/30660470/44471820-ff7db380-a62c-11e8-8f1d-390ccb7305a1.png)
![018](https://user-images.githubusercontent.com/30660470/44471821-00164a00-a62d-11e8-96a1-f967104fa877.png)

This is meant to bridge the gap until the new data set is fully rolled out in Copenhagen and gather some experience with the color scaling. 