### PR TITLE
Fix customised instrument args

### DIFF
--- a/qdev_wrappers/customised_instruments/AWG5014_ext.py
+++ b/qdev_wrappers/customised_instruments/AWG5014_ext.py
@@ -4,8 +4,8 @@ from qcodes.utils import validators as vals
 
 
 class AWG5014_ext(Tektronix_AWG5014):
-    def __init__(self, name, visa_address, **kwargs):
-        super().__init__(name, visa_address, **kwargs)
+    def __init__(self, name, address, **kwargs):
+        super().__init__(name, address, **kwargs)
         self.add_parameter(name='current_seq',
                            parameter_class=ManualParameter,
                            initial_value=None,

--- a/qdev_wrappers/customised_instruments/ZNB_ext.py
+++ b/qdev_wrappers/customised_instruments/ZNB_ext.py
@@ -62,13 +62,13 @@ class ZNB_ext(ZNB):
 
     def __init__(self,
                  name,
-                 visa_address,
+                 address,
                  S21=True,
                  spec_mode=False,
                  gen_address=None,
                  timeout=40):
         super().__init__(
-            name, visa_address, init_s_params=False, timeout=timeout)
+            name, address, init_s_params=False, timeout=timeout)
 
         if S21:
             self.add_channel(channel_name='S21')


### PR DESCRIPTION
ZNB_ext and AWG5014_ext to have address instead of visa_address as init args so that they plan nice with the station configurator.