### PR TITLE
change logging delimiter add logging fields

### DIFF
--- a/qdev_wrappers/logger.py
+++ b/qdev_wrappers/logger.py
@@ -8,7 +8,7 @@ from qcodes import config
 log = logging.getLogger(__name__)
 
 logging_dir = "logs"
-logging_delimiter = '¦'
+logging_delimiter = ' ¦ '
 history_log_name = "history.log"
 python_log_name = 'pythonlog.log'
 
@@ -23,8 +23,7 @@ def start_python_logger() -> None:
     will be written to stderr.
     """
     format_string_items = ['%(asctime)s', '%(name)s', '%(levelname)s',
-                           '%(message)s', '%(filename)s', '%(funcName)s',
-                           '%(lineno)d','%(module)s']
+                           '%(funcName)s', '%(lineno)d', '%(message)s']
     format_string = logging_delimiter.join(format_string_items)
     formatter = logging.Formatter(format_string)
     try:

--- a/qdev_wrappers/logger.py
+++ b/qdev_wrappers/logger.py
@@ -8,6 +8,7 @@ from qcodes import config
 log = logging.getLogger(__name__)
 
 logging_dir = "logs"
+logging_delimiter = '¦'
 history_log_name = "history.log"
 python_log_name = 'pythonlog.log'
 
@@ -21,8 +22,11 @@ def start_python_logger() -> None:
     All logging messages on or above consolelogginglevel
     will be written to stderr.
     """
-    formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    format_string_items = ['%(asctime)s', '%(name)s', '%(levelname)s',
+                           '%(message)s', '%(filename)s', '%(funcName)s',
+                           '%(lineno)d','%(module)s']
+    format_string = logging_delimiter.join(format_string_items)
+    formatter = logging.Formatter(format_string)
     try:
         filelogginglevel = config.core.file_loglevel
     except KeyError:


### PR DESCRIPTION
@WilliamHPNielsen @qdevbb 

example:
```
2018-10-04 14:03:33,760 ¦ qdev_wrappers.logger ¦ INFO ¦ start_python_logger ¦ 49 ¦ QCoDes python logger setup
```