### PR TITLE
Revert "Alazar measuring only Channel A"

### DIFF
--- a/qdev_wrappers/alazar_controllers/ATSChannelController.py
+++ b/qdev_wrappers/alazar_controllers/ATSChannelController.py
@@ -48,10 +48,7 @@ class ATSChannelController(AcquisitionController):
         super().__init__(name, alazar_name, **kwargs)
         self.filter_settings = {'filter': self.filter_dict[filter],
                                 'numtaps': numtaps}
-        if self._get_alazar().channel_selection() in ['A']:
-            self.number_of_channels = 1
-        else:
-            self.number_of_channels = 2
+        self.number_of_channels = 2
 
         channels = ChannelList(self, "Channels", AlazarChannel,
                                multichan_paramclass=AlazarMultiChannelParameter)
@@ -290,8 +287,7 @@ class ATSChannelController(AcquisitionController):
                                            samples_per_record,
                                            self.number_of_channels)
         channelAData = reshaped_buf[..., 0]
-        if self.number_of_channels == 2:
-            channelBData = reshaped_buf[..., 1]
+        channelBData = reshaped_buf[..., 1]
 
         def handle_alazar_channel(channelData,
                                   channel_number: int,


### PR DESCRIPTION
@jenshnielsen I have forgotten to revert this. Had some troubles with this PR as the testing I did was not performed on an actual sample so only tested that the alazar returns data.
After running on a sample it seems that it somehow changes the order of records in the returned data matrix (or the demodulation code somewhere assumes channel A and B records are interleaved).

I propose reverting this and then returning to the issue of single channel measurements at a later point.

Reverts qdev-dk/qdev-wrappers#125 @nataliejpg 