### PR TITLE
Remove unused import

### DIFF
--- a/qdev_wrappers/dataset/doNd.py
+++ b/qdev_wrappers/dataset/doNd.py
@@ -6,8 +6,6 @@ import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
 
-from plottr.qcodes_dataset import QcodesDatasetSubscriber as LivePlotSubscriber
-
 from qcodes.dataset.measurements import Measurement
 from qcodes.instrument.base import _BaseParameter
 from qcodes.dataset.plotting import plot_by_id


### PR DESCRIPTION
Remove an unused import that causes a problem if `plottr` is not installed.