### PR TITLE
plot saving to be specified in config.user

### DIFF
--- a/qdev_wrappers/dataset/doNd.py
+++ b/qdev_wrappers/dataset/doNd.py
@@ -274,8 +274,10 @@ def _save_image(datasaver) -> AxesTupleList:
     os.makedirs(png_dir, exist_ok=True)
     os.makedirs(pdf_dif, exist_ok=True)
 
-    save_pdf = True
-    save_png = True
+    save_settings = config.user.get(
+        'plot_save', {'pdf': True, 'png': True})
+    save_pdf = save_settings['pdf']
+    save_png = save_settings['png']
 
     for i, ax in enumerate(axes):
         if save_pdf:


### PR DESCRIPTION
When using doNd if the 'do_plots' keyword argument is True plots will be generated which are saved in both png and pdf format. This pull request makes the saving configurable via the config file so that you can choose if you want any generated plots to be saved as png, pdf, both or neither :)

TODO:
- [ ] Test

@jenshnielsen 