### PR TITLE
[WIP] create interface parameter

### DIFF
--- a/qdev_wrappers/customised_instruments/interfaces/interface_parameter.py
+++ b/qdev_wrappers/customised_instruments/interfaces/interface_parameter.py
@@ -31,5 +31,5 @@ class InterfaceParameter(Parameter):
             raise RuntimeError(f'Parmeter {self.name} not settable')
         elif self.set_fn is not None:
             self.set_fn(val)
-        elif self.source is not None:
+        if self.source is not None:
             self.source.set(val)

--- a/qdev_wrappers/customised_instruments/interfaces/interface_parameter.py
+++ b/qdev_wrappers/customised_instruments/interfaces/interface_parameter.py
@@ -1,27 +1,35 @@
 from qcodes.instrument.parameter import Parameter
 
-# TODO: doctrings
 
 class InterfaceParameter(Parameter):
     def __init__(self, name, source=None, get_fn=None,
                  set_fn=None, *args, **kwargs):
+    """
+    Parameter which by default behaves like ManualParameter but can
+    be easily configured to get/set a source parameter or run a
+    function when get/set is called. The functions if specified
+    have priority over the source. If a function is False
+    it means the parameter cannot be get/set.
+    """
         self._source = source
         self._set_fn = set_fn
         self._get_fn = get_fn
         super().__init__(name=name, *args, **kwargs)
 
     def get_raw(self):
-        if self._source is not None:
-            return self.source.get()
+        if self._get_fn is False:
+            raise RuntimeError(f'Parmeter {self.name} not gettable')
         elif self._get_fn is not None:
             return self._get_fn()
+        elif self._source is not None:
+            return self.source.get()
         else:
             return self._latest['value']
 
     def set_raw(self, val):
-        if self._source is not None:
-            self.source.set(val)
-        elif self._set_fn is False:
+        if self._set_fn is False:
             raise RuntimeError(f'Parmeter {self.name} not settable')
         elif self._set_fn is not None:
             self._set_fn(val)
+        elif self._source is not None:
+            self.source.set(val)

--- a/qdev_wrappers/customised_instruments/interfaces/interface_parameter.py
+++ b/qdev_wrappers/customised_instruments/interfaces/interface_parameter.py
@@ -4,32 +4,32 @@ from qcodes.instrument.parameter import Parameter
 class InterfaceParameter(Parameter):
     def __init__(self, name, source=None, get_fn=None,
                  set_fn=None, *args, **kwargs):
-    """
-    Parameter which by default behaves like ManualParameter but can
-    be easily configured to get/set a source parameter or run a
-    function when get/set is called. The functions if specified
-    have priority over the source. If a function is False
-    it means the parameter cannot be get/set.
-    """
-        self._source = source
-        self._set_fn = set_fn
-        self._get_fn = get_fn
+        """
+        Parameter which by default behaves like ManualParameter but can
+        be easily configured to get/set a source parameter or run a
+        function when get/set is called. The functions if specified
+        have priority over the source. If a function is False
+        it means the parameter cannot be get/set.
+        """
+        self.source = source
+        self.set_fn = set_fn
+        self.get_fn = get_fn
         super().__init__(name=name, *args, **kwargs)
 
     def get_raw(self):
-        if self._get_fn is False:
+        if self.get_fn is False:
             raise RuntimeError(f'Parmeter {self.name} not gettable')
-        elif self._get_fn is not None:
+        elif self.get_fn is not None:
             return self._get_fn()
-        elif self._source is not None:
+        elif self.source is not None:
             return self.source.get()
         else:
             return self._latest['value']
 
     def set_raw(self, val):
-        if self._set_fn is False:
+        if self.set_fn is False:
             raise RuntimeError(f'Parmeter {self.name} not settable')
-        elif self._set_fn is not None:
-            self._set_fn(val)
-        elif self._source is not None:
+        elif self.set_fn is not None:
+            self.set_fn(val)
+        elif self.source is not None:
             self.source.set(val)

--- a/qdev_wrappers/customised_instruments/interfaces/interface_parameter.py
+++ b/qdev_wrappers/customised_instruments/interfaces/interface_parameter.py
@@ -8,8 +8,9 @@ class InterfaceParameter(Parameter):
         Parameter which by default behaves like ManualParameter but can
         be easily configured to get/set a source parameter or run a
         function when get/set is called. The functions if specified
-        have priority over the source. If a function is False
-        it means the parameter cannot be get/set.
+        have priority over the source. For setting if function and source
+        are specified the function will be executed and then the source set.
+        If a function is False it means the parameter cannot be get/set.
         """
         self.source = source
         self.set_fn = set_fn

--- a/qdev_wrappers/customised_instruments/interfaces/interface_parameter.py
+++ b/qdev_wrappers/customised_instruments/interfaces/interface_parameter.py
@@ -1,0 +1,27 @@
+from qcodes.instrument.parameter import Parameter
+
+# TODO: doctrings
+
+class InterfaceParameter(Parameter):
+    def __init__(self, name, source=None, get_fn=None,
+                 set_fn=None, *args, **kwargs):
+        self._source = source
+        self._set_fn = set_fn
+        self._get_fn = get_fn
+        super().__init__(name=name, *args, **kwargs)
+
+    def get_raw(self):
+        if self._source is not None:
+            return self.source.get()
+        elif self._get_fn is not None:
+            return self._get_fn()
+        else:
+            return self._latest['value']
+
+    def set_raw(self, val):
+        if self._source is not None:
+            self.source.set(val)
+        elif self._set_fn is False:
+            raise RuntimeError(f'Parmeter {self.name} not settable')
+        elif self._set_fn is not None:
+            self._set_fn(val)


### PR DESCRIPTION
Adds a parameter to the customised instruments which can function either as a delegate parameter, or be given function to run for get and set (minimally these are none in which case it behaves like a manual parameter). The thinking behind this is that it makes it much easier to create instrument interfaces with designated parameters and then subclasses can then attach these parameters to functions or real instruments but the higher level code is minimally affected by changing physical instruments and experiment code can be easily tested using simulated instruments.

- [ ] test