### PR TITLE
Sr860 buffered sweeps

### DIFF
--- a/qdev_wrappers/customised_instruments/SR830_ext.py
+++ b/qdev_wrappers/customised_instruments/SR830_ext.py
@@ -15,14 +15,14 @@ class ConductanceBuffer(ChannelBuffer):
         super().__init__(name, instrument, channel=1)
         self.unit = ('e$^2$/h')
 
-    def get(self):
+    def get_raw(self):
         # If X is not being measured, complain
         if self._instrument.ch1_display() != 'X':
             raise ValueError('Can not return conductance since X is not '
                                 'being measured on channel 1.')
 
         resistance_quantum = 25.818e3  # (Ohm)
-        xarray = super().get()
+        xarray = super().get_raw()
         iv_conv = self._instrument.iv_gain()
         ac_excitation = self._instrument.amplitude.get_latest()
 
@@ -42,13 +42,13 @@ class ResistanceBuffer(ChannelBuffer):
         super().__init__(name, instrument, channel=1)
         self.unit = ('Ohm')
 
-    def get(self):
+    def get_raw(self):
         # If X is not being measured, complain
         if self._instrument.ch1_display() != 'X':
             raise ValueError('Can not return conductance since X is not '
                                 'being measured on channel 1.')
 
-        xarray = super().get()
+        xarray = super().get_raw()
         v_conv = self._instrument.v_gain()
         ac_excitation = self._instrument.amplitude.get_latest()
 

--- a/qdev_wrappers/customised_instruments/SR830_ext.py
+++ b/qdev_wrappers/customised_instruments/SR830_ext.py
@@ -62,10 +62,10 @@ class soft_sweep():
     '''
     Helper class to utilize buffers within doNd measurements.
     How to:
-        do0d(lockin.soft_sweep(para_set, start, stor, num_points, delay), lockin.g_buff)
+        do0d(lockin.soft_sweep.sweep(para_set, start, stor, num_points, delay), lockin.g_buff)
     The class can be instanciated with a list of lockins if multiple needs to be measured at each point:
     Nlockin_sweep = soft_sweep((lockin1,lockin2))
-        do0d(Nlockin_sweep(para_set, start, stor, num_points, delay), lockin1.g_buff, lockin2.g_buff)
+        do0d(Nlockin_sweep.sweep(para_set, start, stor, num_points, delay), lockin1.g_buff, lockin2.g_buff)
     '''
     def __init__(self, lockins):
         self.lockins = lockins
@@ -77,8 +77,6 @@ class soft_sweep():
         self.setpoints = np.linspace(start, stop, num_points)
         for lockin in self.lockins:
             lockin.buffer_SR('Trigger')
-            lockin.buffer_reset
-            lockin.buffer_start
             # Get list of ChannelBuffer type attributes on lockin
             buffer_list = [getattr(lockin, name) 
                             for name in dir(lockin) 
@@ -94,6 +92,9 @@ class soft_sweep():
         return self.perform_sweep
     
     def perform_sweep(self):
+        for lockin in self.lockins:
+            lockin.buffer_reset()
+            lockin.buffer_start()
         for set_val in self.setpoints:
             self.param_set(set_val)
             for lockin in self.lockins:


### PR DESCRIPTION
Pull request for lockin amplifier measurements taking advantage of the buffers in SR830, which is significantly faster than querying data for each point.
Idea was to make it look as much as possible as a do2d scan from the user perspective.

@ectof this is somewhat less general than what you had made. But I think it is fine to make it a bit less general and only for lockins. However, we should expand the feature to SR860's at some point.