### PR TITLE
[WIP] Alazar Software Downconversion

### DIFF
--- a/qdev_wrappers/alazar_controllers/ATSChannelController.py
+++ b/qdev_wrappers/alazar_controllers/ATSChannelController.py
@@ -2,6 +2,7 @@ import logging
 from typing import Union, Sequence, Tuple, List
 
 import numpy as np
+from scipy import signal
 
 import qdev_wrappers.alazar_controllers.acq_helpers as helpers
 from qcodes import ChannelList
@@ -316,8 +317,11 @@ class ATSChannelController(AcquisitionController):
 
             data = []
             if raw:
+                decimation_factor = settings.get('software_decimation_factor', 1)
                 if settings['integrate_samples']:
                     data.append(np.squeeze(np.mean(recordA, axis=-1)))
+                elif not decimation_factor == 1:
+                    data.append(signal.decimate(recordA, decimation_factor))
                 else:
                     data.append(np.squeeze(recordA))
             # do demodulation

--- a/qdev_wrappers/alazar_controllers/alazar_channel.py
+++ b/qdev_wrappers/alazar_controllers/alazar_channel.py
@@ -24,7 +24,8 @@ class AlazarChannel(InstrumentChannel):
     def __init__(self, parent, name: str, demod: bool=False, alazar_channel: str='A',
                  average_buffers: bool=True,
                  average_records: bool=True,
-                 integrate_samples: bool=True) -> None:
+                 integrate_samples: bool=True,
+                 software_decimation_factor: int=1) -> None:
 
 
         super().__init__(parent, name)
@@ -34,6 +35,7 @@ class AlazarChannel(InstrumentChannel):
         self._average_buffers = average_buffers
         self._average_records = average_records
         self._integrate_samples = integrate_samples
+    
         if self.dimensions > 0:
             self._stale_setpoints = True
         else:
@@ -42,6 +44,11 @@ class AlazarChannel(InstrumentChannel):
         if self.dimensions >= 3:
             raise RuntimeError("Alazar controller only supports up to 2 dimensional arrays")
 
+        self.add_parameter('software_decimation_factor',
+                           label='software decimation factor',
+                           initial_value=software_decimation_factor,
+                           vals=vals.Multiples(divisor=128),
+                           get_cmd=None, set_cmd=None)
         self._demod = demod
         if demod:
             self.add_parameter('demod_freq',

--- a/qdev_wrappers/alazar_controllers/alazar_multidim_parameters.py
+++ b/qdev_wrappers/alazar_controllers/alazar_multidim_parameters.py
@@ -121,6 +121,7 @@ class AlazarNDParameter(ArrayParameter):
         cntrl.shape_info['average_buffers'] = channel._average_buffers
         cntrl.shape_info['average_records'] = channel._average_records
         cntrl.shape_info['integrate_samples'] = channel._integrate_samples
+        cntrl.shape_info['software_decimation_factor'] = channel.software_decimation_factor()
         cntrl.shape_info['output_order'] = [0]
 
         params_to_kwargs = ['samples_per_record', 'records_per_buffer',
@@ -187,7 +188,9 @@ class Alazar1DParameter(AlazarNDParameter):
         # int_delay = self._instrument.int_delay.get() or 0
         # total_time = int_time + int_delay
         if not self._integrate_samples:
+            software_decimation_factor = self._instrument.software_decimation_factor.get()
             samples = self._instrument._parent.samples_per_record.get()
+            samples = int(samples/software_decimation)
             sample_rate = self._instrument._parent._get_alazar().get_sample_rate()
             start = 0
             stop = samples/sample_rate
@@ -251,7 +254,10 @@ class Alazar2DParameter(AlazarNDParameter):
     def set_setpoints_and_labels(self):
         records = self._instrument.records_per_buffer()
         buffers = self._instrument.buffers_per_acquisition()
+
+        software_decimation_factor = self._instrument.software_decimation_factor.get()
         samples = self._instrument._parent.samples_per_record.get()
+        samples = int(samples/software_decimation_factor)
         if self._integrate_samples:
             self.shape = (buffers,records)
             inner_setpoints = tuple(np.linspace(0, records, records, endpoint=False))


### PR DESCRIPTION
At request of Fabio
@fabioansaloni 
This PR introduces a parameter `software_decimation_factor` for the AlazarChannel. The records get decimated by `scipy.signal.decimate`
Current shortcomming: all records get decimated. The decimation does not take place at a channel level even thought the placement of the parameter might suggest so.