### PR TITLE
[WIP] Add complex demodulation support to Alazar controller

### DIFF
--- a/qdev_wrappers/alazar_controllers/ATSChannelController.py
+++ b/qdev_wrappers/alazar_controllers/ATSChannelController.py
@@ -333,6 +333,8 @@ class ATSChannelController(AcquisitionController):
                         mydata = Real_data
                     elif demodtype == 'imag':
                         mydata = Imag_data
+                    elif demodtype == 'phasor':
+                        mydata = Real_data + 1j*Imag_data
                     else:
                         raise RuntimeError(f"Unknown demodulator type {demodtype} supplied")
                     data.append(mydata)

--- a/qdev_wrappers/alazar_controllers/alazar_channel.py
+++ b/qdev_wrappers/alazar_controllers/alazar_channel.py
@@ -52,7 +52,7 @@ class AlazarChannel(InstrumentChannel):
             self.add_parameter('demod_type',
                                label='demod type',
                                initial_value='magnitude',
-                               vals=vals.Enum('magnitude', 'phase', 'real', 'imag'),
+                               vals=vals.Enum('magnitude', 'phase', 'real', 'imag', 'phasor'),
                                get_cmd=None, set_cmd=None)
 
         self.add_parameter('alazar_channel',


### PR DESCRIPTION
This PR is a simple addition of the option `phasor` as a demodulation type of AlazarChannels. When phasor is chosen the the data will be returned as a complex numpy array.