### PR TITLE
Add `set_before_sweep` to `do2d` for new Dataset

### DIFF
--- a/qdev_wrappers/dataset/doNd.py
+++ b/qdev_wrappers/dataset/doNd.py
@@ -214,14 +214,18 @@ def do2d(param_set1: _BaseParameter, start1: number, stop1: number,
                                     setpoints=(param_set1, param_set2))
     try:
         with meas.run() as datasaver:
-            # set_before_sweep feature variable:
-            skip_setting_first_inner_setpoint = False
             for set_point1 in np.linspace(start1, stop1, num_points1):
+                if set_before_sweep:
+                    param_set2.set(start2)
+
                 param_set1.set(set_point1)
                 for action in before_inner_actions:
                     action()
                 for set_point2 in np.linspace(start2, stop2, num_points2):
-                    if not skip_setting_first_inner_setpoint:
+                    # skip first inner set point if `set_before_sweep`
+                    if set_point2 == start2 and set_before_sweep:
+                        pass
+                    else:
                         param_set2.set(set_point2)
                     output = []
                     for parameter in param_meas:
@@ -232,9 +236,6 @@ def do2d(param_set1: _BaseParameter, start1: number, stop1: number,
                     datasaver.add_result((param_set1, set_point1),
                                          (param_set2, set_point2),
                                          *output)
-                if set_before_sweep:
-                    param_set2.set(start2)
-                    skip_setting_first_inner_setpoint = True
                 for action in after_inner_actions:
                     action()
     except KeyboardInterrupt:

--- a/qdev_wrappers/dataset/doNd.py
+++ b/qdev_wrappers/dataset/doNd.py
@@ -151,6 +151,7 @@ def do2d(param_set1: _BaseParameter, start1: number, stop1: number,
          param_set2: _BaseParameter, start2: number, stop2: number,
          num_points2: int, delay2: number,
          *param_meas: Union[_BaseParameter, Callable[[], None]],
+         set_before_sweep: Optional[bool] = False,
          enter_actions: Sequence[Callable[[], None]] = (),
          exit_actions: Sequence[Callable[[], None]] = (),
          before_inner_actions: Sequence[Callable[[], None]] = (),
@@ -177,6 +178,8 @@ def do2d(param_set1: _BaseParameter, start1: number, stop1: number,
           will be called at each step. The function should take no arguments.
           The parameters and functions are called in the order they are
           supplied.
+        set_before_sweep: if True the outer parameter is set to its first value
+            before the inner parameter is swept to its next value.
         enter_actions: A list of functions taking no arguments that will be
             called before the measurements start
         exit_actions: A list of functions taking no arguments that will be
@@ -211,13 +214,15 @@ def do2d(param_set1: _BaseParameter, start1: number, stop1: number,
                                     setpoints=(param_set1, param_set2))
     try:
         with meas.run() as datasaver:
-
+            # set_before_sweep feature variable:
+            param_set2_has_been_set_before_sweep = False
             for set_point1 in np.linspace(start1, stop1, num_points1):
                 param_set1.set(set_point1)
                 for action in before_inner_actions:
                     action()
                 for set_point2 in np.linspace(start2, stop2, num_points2):
-                    param_set2.set(set_point2)
+                    if not param_set2_has_been_set_before_sweep:
+                        param_set2.set(set_point2)
                     output = []
                     for parameter in param_meas:
                         if isinstance(parameter, _BaseParameter):
@@ -227,6 +232,9 @@ def do2d(param_set1: _BaseParameter, start1: number, stop1: number,
                     datasaver.add_result((param_set1, set_point1),
                                          (param_set2, set_point2),
                                          *output)
+                if set_before_sweep:
+                    param_set2.set(start2)
+                    param_set2_has_been_set_before_sweep = True
                 for action in after_inner_actions:
                     action()
     except KeyboardInterrupt:

--- a/qdev_wrappers/dataset/doNd.py
+++ b/qdev_wrappers/dataset/doNd.py
@@ -215,13 +215,13 @@ def do2d(param_set1: _BaseParameter, start1: number, stop1: number,
     try:
         with meas.run() as datasaver:
             # set_before_sweep feature variable:
-            param_set2_has_been_set_before_sweep = False
+            skip_setting_first_inner_setpoint = False
             for set_point1 in np.linspace(start1, stop1, num_points1):
                 param_set1.set(set_point1)
                 for action in before_inner_actions:
                     action()
                 for set_point2 in np.linspace(start2, stop2, num_points2):
-                    if not param_set2_has_been_set_before_sweep:
+                    if not skip_setting_first_inner_setpoint:
                         param_set2.set(set_point2)
                     output = []
                     for parameter in param_meas:
@@ -234,7 +234,7 @@ def do2d(param_set1: _BaseParameter, start1: number, stop1: number,
                                          *output)
                 if set_before_sweep:
                     param_set2.set(start2)
-                    param_set2_has_been_set_before_sweep = True
+                    skip_setting_first_inner_setpoint = True
                 for action in after_inner_actions:
                     action()
     except KeyboardInterrupt:


### PR DESCRIPTION
Transfer the feature `set_before_sweep` from the 'old' `do2d` to the one compatible with the new dataset upon user request.
Here comes also a small improvement: The first value of the inner set points will no longer be set twice.