### PR TITLE
Fix delay in `do2d`

### DIFF
--- a/qdev_wrappers/dataset/doNd.py
+++ b/qdev_wrappers/dataset/doNd.py
@@ -194,7 +194,7 @@ def do2d(param_set1: _BaseParameter, start1: number, stop1: number,
     meas.register_parameter(param_set1)
     param_set1.post_delay = delay1
     meas.register_parameter(param_set2)
-    param_set1.post_delay = delay2
+    param_set2.post_delay = delay2
     interrupted = False
     for action in enter_actions:
         # this omits the possibility of passing


### PR DESCRIPTION
Currently the delay in `do2d` is not having any effect for the inner set point parameter, due to a typo. This PR fixes this.