### PR TITLE
Add `write_period` as a kwarg to `dond`s

### DIFF
--- a/qdev_wrappers/dataset/doNd.py
+++ b/qdev_wrappers/dataset/doNd.py
@@ -20,6 +20,7 @@ number = Union[float, int]
 
 
 def do0d(*param_meas:  Union[_BaseParameter, Callable[[], None]],
+         write_period: Optional[float] = None,
          do_plot: bool = True) -> AxesTupleListWithRunId:
     """
     Perform a measurement of a single parameter. This is probably most
@@ -37,6 +38,8 @@ def do0d(*param_meas:  Union[_BaseParameter, Callable[[], None]],
         The run_id of the DataSet created
     """
     meas = Measurement()
+    if write_period:
+        meas.write_period = write_period
     output = []
 
     for parameter in param_meas:
@@ -67,6 +70,7 @@ def do1d(param_set: _BaseParameter, start: number, stop: number,
          *param_meas: Union[_BaseParameter, Callable[[], None]],
          enter_actions: Sequence[Callable[[], None]] = (),
          exit_actions: Sequence[Callable[[], None]] = (),
+         write_period: Optional[float] = None,
          do_plot: bool = True) \
         -> AxesTupleListWithRunId:
     """
@@ -95,6 +99,8 @@ def do1d(param_set: _BaseParameter, start: number, stop: number,
         The run_id of the DataSet created
     """
     meas = Measurement()
+    if write_period:
+        meas.write_period = write_period
     meas.register_parameter(
         param_set)  # register the first independent parameter
     output = []
@@ -155,6 +161,7 @@ def do2d(param_set1: _BaseParameter, start1: number, stop1: number,
          exit_actions: Sequence[Callable[[], None]] = (),
          before_inner_actions: Sequence[Callable[[], None]] = (),
          after_inner_actions: Sequence[Callable[[], None]] = (),
+         write_period: Optional[float] = None,
          do_plot: bool=True) -> AxesTupleListWithRunId:
 
     """
@@ -191,6 +198,8 @@ def do2d(param_set1: _BaseParameter, start1: number, stop1: number,
     """
 
     meas = Measurement()
+    if write_period:
+        meas.write_period = write_period
     meas.register_parameter(param_set1)
     param_set1.post_delay = delay1
     meas.register_parameter(param_set2)

--- a/qdev_wrappers/dataset/doNd.py
+++ b/qdev_wrappers/dataset/doNd.py
@@ -162,6 +162,7 @@ def do2d(param_set1: _BaseParameter, start1: number, stop1: number,
          before_inner_actions: Sequence[Callable[[], None]] = (),
          after_inner_actions: Sequence[Callable[[], None]] = (),
          write_period: Optional[float] = None,
+         flush_columns: bool = False,
          do_plot: bool=True) -> AxesTupleListWithRunId:
 
     """
@@ -238,6 +239,8 @@ def do2d(param_set1: _BaseParameter, start1: number, stop1: number,
                                          *output)
                 for action in after_inner_actions:
                     action()
+                if flush_columns:
+                    datasaver.flush_data_to_database()
     except KeyboardInterrupt:
         interrupted = True
 

--- a/qdev_wrappers/dataset/doNd.py
+++ b/qdev_wrappers/dataset/doNd.py
@@ -38,7 +38,7 @@ def do0d(*param_meas:  Union[_BaseParameter, Callable[[], None]],
         The run_id of the DataSet created
     """
     meas = Measurement()
-    if write_period:
+    if write_period is not None:
         meas.write_period = write_period
     output = []
 
@@ -99,7 +99,7 @@ def do1d(param_set: _BaseParameter, start: number, stop: number,
         The run_id of the DataSet created
     """
     meas = Measurement()
-    if write_period:
+    if write_period is not None:
         meas.write_period = write_period
     meas.register_parameter(
         param_set)  # register the first independent parameter
@@ -199,7 +199,7 @@ def do2d(param_set1: _BaseParameter, start1: number, stop1: number,
     """
 
     meas = Measurement()
-    if write_period:
+    if write_period is not None:
         meas.write_period = write_period
     meas.register_parameter(param_set1)
     param_set1.post_delay = delay1


### PR DESCRIPTION
Currently there is no way of setting the `write_periode` in `dond` calls. The implementation of this keywords follows the wish to have faster live plotting.