### PR TITLE
Add deprecation warning to station_configurator

### DIFF
--- a/qdev_wrappers/station_configurator.py
+++ b/qdev_wrappers/station_configurator.py
@@ -29,6 +29,9 @@ enable_forced_reconnect = qcodes.config["station_configurator"]["enable_forced_r
 default_folder = qcodes.config["station_configurator"]["default_folder"]
 default_file = qcodes.config["station_configurator"]["default_file"]
 
+warnings.warn('The station_configurator.py of qdev-wrappers is deprecated and will be '
+              'removed soon. Please use station.py of QCoDeS instead.')
+
 
 class StationConfigurator:
     """


### PR DESCRIPTION
This PR deprecates the Wrappers station configurator in favor of QCoDeS Station object.