### PR TITLE
Remove _latest from alazar controller

### DIFF
--- a/qdev_wrappers/alazar_controllers/acquisition_parameters.py
+++ b/qdev_wrappers/alazar_controllers/acquisition_parameters.py
@@ -37,10 +37,9 @@ class AcqVariablesParam(Parameter):
             value: value to set the parameter to
         """
         self._check_and_update_instr(value, param_name=self.name)
-        self._save_val(value)
 
     def get_raw(self):
-        return self._latest['value']
+        return self.cache.get()
 
     def to_default(self):
         """
@@ -63,7 +62,7 @@ class AcqVariablesParam(Parameter):
         Return:
             True (if no errors raised when check_and_update_fn executed)
         """
-        val = self._latest['value']
+        val = self.cache.get()
         self._check_and_update_instr(val, param_name=self.name)
         return True
 


### PR DESCRIPTION
With the update of the cache the private property `_latest` of the `Parameter` is no longer available. This fixes the usage in the Alazar controller. @astafan8

(The save_val I removed is not a bug, but as it will be deprecated I removed it in one go. The cache will be updated anyways in the set wrapper, so it does not need to be called)